### PR TITLE
docs: add comprehensive workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,123 @@
 # Claude Workflow System
 
-Personal AI engineering system based on the AI-Human Engineering Stack.
-Updated for Claude Code with hooks, custom agents, and worktree support.
+A portable AI engineering system for Claude Code that applies automatically to every project. Built on the Compound Engineering philosophy: each unit of work makes subsequent units easier — not harder.
 
-## What This Is
+Based on The AI-Human Engineering Stack and The Complete Guide to Specifying Work for AI (Mill & Sanchez, 2026).
 
-Portable development workflow for Claude Code. Applies automatically
-to any project. Contains: methodology (CLAUDE.md), enforcement (hooks),
-specialized agents, skills (auto-invoked and manual), and reference docs.
+## Quick Start
 
-## Setup on New Machine
+```bash
+# 1. Clone to ~/.claude/
+git clone <repository-url> ~/.claude
 
-1. Clone this repo to `~/.claude/`
-2. Open any project with Claude Code — the workflow applies automatically
-3. Hooks enforce rules deterministically (auto-format, block dangerous commands)
-4. Agents are available for sprint execution and code review
-5. Skills auto-invoke based on conversation context (no setup needed)
-6. Project-specific context goes in the project's own CLAUDE.md
+# 2. Open any project with Claude Code
+cd /path/to/your/project
+claude
 
-## Structure
+# 3. That's it — the system loads automatically
+```
 
-- `CLAUDE.md` — Main engineering system (intent, workflow, context, judgment, evaluation)
-- `settings.json` — Hooks & enforcement (auto-format, blockers, anti-Goodhart Stop hook)
-- `agents/` — Custom subagents with own context windows
-  - `orchestrator.md` — Sprint lifecycle manager (delegates, never implements)
-  - `sprint-executor.md` — Sprint implementation (isolated worktree)
-  - `code-reviewer.md` — Read-only review agent
-- `skills/` — Auto-invocable skills with supporting files
-  - `plan/` — PRD generation only (auto-invoked)
-  - `plan-build-test/` — Discover, plan, execute, verify locally (auto-invoked)
-  - `ship-test-ensure/` — Deploy pipeline: staging, E2E, production, Lighthouse (auto-invoked)
-  - `compound/` — Post-task learning capture (auto-invoked)
-- `docs/` — Standalone reference material
-  - `evaluation-reference.md` — Stack Evaluation, Diagnostic Loop, Spec Self-Evaluator
-  - `anti-patterns-full.md` — Expanded anti-patterns with examples and fixes
-  - `vague-requirements-translator.md` — Vague to measurable requirement translations
+Hooks enforce rules deterministically, agents handle complex work, and skills auto-invoke based on what you're doing. Project-specific context goes in each project's own `CLAUDE.md` (see [Getting Started](workflow/02-getting-started.md)).
 
-## Based On
+## How It Works
 
-- The AI-Human Engineering Stack (Mill & Sanchez, 2026)
-- The Complete Guide to Specifying Work for AI (Mill & Sanchez, 2026)
+```
+PLAN → WORK → REVIEW → COMPOUND → (next task is now easier)
+```
+
+The core loop. Plan + Review = 80% of effort. Work + Compound = 20%. The bottleneck is knowing **what** to build and **verifying** it was built correctly — not typing speed.
+
+## Repository Structure
+
+```
+~/.claude/
+├── CLAUDE.md          # The brain — all rules, workflows, and judgment protocols
+├── settings.json      # Deterministic enforcement via hooks
+├── agents/            # Specialized workers with isolated context windows
+│   ├── orchestrator.md    # Delegates and coordinates — never implements
+│   ├── sprint-executor.md # Implements sprints in isolated worktrees
+│   └── code-reviewer.md   # Read-only auditor — reports, never fixes
+├── skills/            # Auto-invocable step-by-step workflows
+│   ├── plan/              # PRD generation (/plan)
+│   ├── plan-build-test/   # Local pipeline: discover → plan → execute → verify
+│   ├── ship-test-ensure/  # Deploy: branch → PR → staging → E2E → production
+│   ├── compound/          # Post-task learning capture
+│   └── workflow-audit/    # Periodic system self-review
+├── hooks/             # Safety enforcement scripts
+│   ├── block-dangerous.sh     # Blocks rm -rf, force push, npm
+│   ├── post-edit-quality.sh   # Auto-formats TS/JS after every edit
+│   ├── end-of-turn-typecheck.sh # Type-checks before session end
+│   └── compound-reminder.sh   # Blocks session end without learning capture
+├── docs/              # Reference material (loaded on demand, not every session)
+│   ├── evaluation-reference.md
+│   ├── anti-patterns-full.md
+│   ├── verification-gates.md
+│   └── project-claude-md-template.md
+├── workflow/          # Full documentation (you are here)
+└── evolution/         # Cross-project learning data
+    ├── error-registry.json     # Error patterns across all projects
+    ├── model-performance.json  # Model success rate tracking
+    └── workflow-changelog.md   # System evolution history
+```
+
+## The Five Skills
+
+| Skill | What It Does | When to Use |
+|---|---|---|
+| `/plan` | Generates PRD only | "Just plan, don't build yet" |
+| `/plan-build-test` | Plans, executes with agent teams, verifies locally | "Build this feature / fix this bug" |
+| `/ship-test-ensure` | Branch, PR, staging E2E, production deploy, Lighthouse | "Ship what I've built" |
+| `/compound` | Captures learnings, updates error registry, evolves system | Auto-invoked after task completion |
+| `/workflow-audit` | Reviews model performance, error patterns, rule staleness | Monthly or after 10+ sessions |
+
+**Autonomous pipeline:** `/plan` → review PRD → `/plan-build-test` (autonomous) → manual test → `/ship-test-ensure` (autonomous through staging, confirms before production).
+
+## The Three Agents
+
+| Agent | Role | Model | Key Constraint |
+|---|---|---|---|
+| **Orchestrator** | Delegates, coordinates, merges | sonnet | Never implements code directly |
+| **Sprint Executor** | Implements sprints in isolation | sonnet | Cannot delegate to other agents |
+| **Code Reviewer** | Read-only post-merge audit | sonnet | Cannot modify any files |
+
+## Safety Enforcement (Hooks)
+
+The system uses deterministic hooks — real code that runs before/after every action. Unlike CLAUDE.md instructions (which the model might ignore), hooks **cannot be bypassed**.
+
+| Hook | Trigger | What It Does |
+|---|---|---|
+| `block-dangerous.sh` | Every Bash command | Blocks `rm -rf /`, force push, npm |
+| `post-edit-quality.sh` | Every file edit | Auto-formats TS/JS (Biome or ESLint) |
+| `end-of-turn-typecheck.sh` | Session end | Type-checks TypeScript |
+| `compound-reminder.sh` | Session end | Blocks exit without learning capture |
+
+## Full Documentation
+
+Detailed documentation lives in [`workflow/`](workflow/):
+
+### Getting Started
+- [Introduction](workflow/01-introduction.md) — What this system is, why it exists, and the Compound Engineering philosophy
+- [Getting Started](workflow/02-getting-started.md) — Installation, setup, first run, and project configuration
+
+### Understanding the System
+- [Architecture](workflow/03-architecture.md) — Repository structure, layers, and how everything connects
+- [The Constitution](workflow/04-constitution.md) — Value hierarchy, decision boundaries, and autonomous authority
+- [Workflow & Modes](workflow/05-workflow-and-modes.md) — Execution modes, Contract-First pattern, and the autonomous pipeline
+- [Sprint System](workflow/06-sprint-system.md) — PRDs, sprint decomposition, templates, and file boundaries
+
+### Components
+- [Agents](workflow/07-agents.md) — Orchestrator, Sprint Executor, and Code Reviewer in depth
+- [Skills Reference](workflow/08-skills-reference.md) — All five skills with full phase breakdowns
+- [Hooks & Enforcement](workflow/09-hooks-and-enforcement.md) — `settings.json`, hook lifecycle, and adding custom hooks
+- [Evolution & Learning](workflow/10-evolution-and-learning.md) — Cross-project learning, error registry, model performance
+
+### Quality & Verification
+- [Verification & Quality](workflow/11-verification-and-quality.md) — 6 verification gates, Anti-Goodhart, Anti-Premature Completion
+
+### Specialized Topics
+- [proot-distro Guide](workflow/12-proot-distro-guide.md) — ARM64 environment setup, known issues, and workarounds
+- [End-to-End Example](workflow/13-end-to-end-example.md) — Complete walkthrough from feature request to production
+
+### Reference
+- [Design Principles](workflow/14-design-principles.md) — 10 recurring principles that guide the entire system
+- [Glossary](workflow/15-glossary.md) — Terms and definitions

--- a/workflow/01-introduction.md
+++ b/workflow/01-introduction.md
@@ -1,0 +1,74 @@
+# Introduction
+
+## What Is Claude Code?
+
+Claude Code is a command-line tool (CLI) by Anthropic that lets you interact with the Claude AI model directly from your terminal for software development tasks. Unlike a chatbot, Claude Code can read files, edit code, run shell commands, navigate your file system, and delegate tasks to sub-agents — all autonomously or semi-autonomously.
+
+When you open Claude Code in any project directory, it automatically loads a file called `CLAUDE.md`. This file acts as permanent instructions — everything in it is read by Claude at the start of every session, functioning as long-term memory for that specific project.
+
+## The Problem This System Solves
+
+Imagine opening Claude Code every day and having to explain everything from scratch: "use pnpm not npm", "run tests before committing", "don't delete passing tests". This is exhausting and inefficient.
+
+The `~/.claude/` repository solves this by creating a **portable engineering system** that lives in your home directory. When you clone it to `~/.claude/`, it applies **automatically to every project** you open with Claude Code. Whether it's a Next.js app, a Python backend, or a Go API — the workflow, safety rules, and specialized agents are always available.
+
+Think of it as the difference between a junior developer who follows one-off instructions and a senior engineer with a refined personal system built over years. This repository is that personal system — codified in files that Claude Code understands.
+
+## The Core Philosophy: Compound Engineering
+
+The opening line of the main `CLAUDE.md` says:
+
+> "Each unit of work must make subsequent units easier — not harder."
+
+This is **Compound Engineering** — engineering that compounds, like compound interest. Each task the AI agent completes not only delivers the requested result, but also **improves the system itself** so the next task is easier, faster, and has fewer errors.
+
+The cycle has four steps:
+
+```
+                    ┌──────────────┐
+                    │     PLAN     │ ◄── Understand & document
+                    └──────┬───────┘
+                           │
+                           ▼
+                    ┌──────────────┐
+                    │     WORK     │ ◄── Implement the code
+                    └──────┬───────┘
+                           │
+                           ▼
+                    ┌──────────────┐
+                    │    REVIEW    │ ◄── Verify correctness
+                    └──────┬───────┘
+                           │
+                           ▼
+                    ┌──────────────┐
+                    │   COMPOUND   │ ◄── Capture learnings,
+                    └──────┬───────┘     improve the system
+                           │
+                           ▼
+                    ┌──────────────┐
+               ┌───►│  NEXT TASK   │ ◄── Now easier because
+               │    └──────────────┘     the system improved
+               │           │
+               └───────────┘
+```
+
+The key insight is step four — **Compound**. Without it, you have "traditional engineering with AI assistance." With it, you have a system that **evolves with every use**.
+
+## Effort Distribution
+
+The recommended split: **Plan + Review = 80%** of effort, **Work + Compound = 20%**.
+
+This sounds counterintuitive — why spend more time planning and reviewing than coding? Because with AI agents, the bottleneck is not typing speed. The bottleneck is knowing **what** to build and **verifying** it was built correctly. If you plan well and review well, implementation becomes almost mechanical — perfect for delegating to an AI agent.
+
+## Intellectual Origins
+
+This system draws from:
+
+- **The AI-Human Engineering Stack** (Mill & Sanchez, 2026) — a layered model for AI engineering where each layer (Prompt, Context, Intent, Judgment, Coherence) has a distinct role
+- **The Complete Guide to Specifying Work for AI** (Mill & Sanchez, 2026) — practical methods for translating human intent into AI-readable specifications
+
+The repository implements these concepts in practice, turning theory into a working system with real files, hooks, and agents.
+
+---
+
+Next: [Getting Started](02-getting-started.md)

--- a/workflow/02-getting-started.md
+++ b/workflow/02-getting-started.md
@@ -1,0 +1,138 @@
+# Getting Started
+
+## Prerequisites
+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed
+- Git installed
+- Node.js 18+ (if working with TypeScript/JavaScript projects)
+- pnpm (recommended package manager — the system enforces pnpm over npm)
+
+## Installation
+
+### Step 1: Clone the Repository
+
+```bash
+# If ~/.claude/ already exists, back it up first
+mv ~/.claude ~/.claude.backup 2>/dev/null
+
+# Clone the workflow system
+git clone <repository-url> ~/.claude
+```
+
+### Step 2: Verify the Structure
+
+```bash
+ls ~/.claude/
+# Expected: CLAUDE.md  README.md  settings.json  agents/  skills/  hooks/  docs/  evolution/
+```
+
+### Step 3: Open Any Project
+
+```bash
+cd /path/to/your/project
+claude  # Start Claude Code — the system loads automatically
+```
+
+That's it. The system applies automatically to every project you open with Claude Code.
+
+## How Auto-Loading Works
+
+When Claude Code starts in any directory, it searches for `CLAUDE.md` files in several locations:
+
+1. **`~/.claude/CLAUDE.md`** — Your global instructions (this system)
+2. **`./CLAUDE.md`** — Project-specific instructions in the current directory
+3. **`./CLAUDE.md` in parent directories** — Inherited instructions
+
+The global `CLAUDE.md` from `~/.claude/` is **always loaded**, providing the base workflow. Project-specific `CLAUDE.md` files add project-specific commands, URLs, and conventions.
+
+## Setting Up a New Project
+
+For each project you work on, create a project-specific `CLAUDE.md` with an **Execution Config** section. This tells the skills what commands to run and where things are.
+
+### Minimal Project CLAUDE.md
+
+```markdown
+# Project Name
+
+Brief description of what this project is.
+
+## Execution Config
+
+### Commands
+- build: `pnpm build`
+- test: `pnpm test`
+- lint: `pnpm lint`
+- type-check: `pnpm tsc --noEmit`
+- dev: `pnpm dev`
+- kill: `pkill -f 'next-server' 2>/dev/null; true`
+
+### Paths
+- session-learnings-path: `docs/session-learnings.md`
+- task-file-location: `docs/tasks`
+
+### GitHub
+- github-repo: `your-org/your-repo`
+
+## Stack
+- Next.js 15, React 19, TypeScript
+- Database: PostgreSQL with Drizzle ORM
+- Styling: Tailwind CSS
+
+## Project-Specific Rules
+- Use server components by default
+- API routes go in `app/api/`
+```
+
+A full template is available at `~/.claude/docs/project-claude-md-template.md`.
+
+### Why Execution Config Matters
+
+Skills like `/plan-build-test` and `/ship-test-ensure` never hardcode project details. Every command, URL, and path comes from the project's `CLAUDE.md`. This makes the skills portable across any project — the system works identically whether you're building a blog or a payment platform.
+
+## First Run Checklist
+
+After installation, verify everything works:
+
+1. **Start Claude Code** in any project directory
+2. **Try a Quick Fix** — ask Claude to fix something small (typo, CSS change). This exercises the basic workflow without the full pipeline.
+3. **Check hooks are active** — try typing `npm install` in a Bash command. The `block-dangerous.sh` hook should block it and suggest `pnpm install` instead.
+4. **Test auto-formatting** — edit a TypeScript file. The `post-edit-quality.sh` hook should auto-format it after saving.
+5. **Try `/plan`** — describe a feature. The planning skill should auto-invoke and walk you through Contract-First and Correctness Discovery.
+
+## What Loads When
+
+Understanding what loads when helps you manage context efficiently:
+
+| What | When It Loads | Context Cost |
+|------|---------------|--------------|
+| `CLAUDE.md` | Every session start | ~650 lines (always) |
+| `settings.json` hooks | Every tool use | Zero (runs as scripts) |
+| Agent files | When an agent is spawned | Per-agent context window |
+| Skill files | When a skill is invoked | Injected into conversation |
+| `docs/` files | When referenced by a skill | On-demand only |
+| `evolution/` data | During `/compound` and `/workflow-audit` | On-demand only |
+
+The key insight: `CLAUDE.md` is the only file that costs context every session. Everything else loads on demand. Keep `CLAUDE.md` dense and essential; put detailed reference material in `docs/`.
+
+## Configuration Options
+
+### `settings.json` Key Settings
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `ENABLE_LSP_TOOL` | `"1"` | Enables Language Server Protocol for code navigation |
+| `NODE_OPTIONS` | `"--max-old-space-size=2048"` | Increases Node.js memory limit |
+| `CHOKIDAR_USEPOLLING` | `"true"` | Enables polling-based file watching |
+| `effortLevel` | `"high"` | Claude invests more reasoning in responses |
+| `defaultMode` | `"bypassPermissions"` | Allows autonomous execution (compensated by hooks) |
+
+### Customization
+
+- **Add project-specific hooks** — extend `settings.json` with project-specific PreToolUse/PostToolUse hooks
+- **Adjust model assignments** — modify the Model Assignment Matrix in `CLAUDE.md` based on your needs
+- **Add new agents** — create new `.md` files in `agents/` with appropriate frontmatter
+- **Create new skills** — add new directories in `skills/` with a `SKILL.md` file
+
+---
+
+Next: [Architecture](03-architecture.md)

--- a/workflow/03-architecture.md
+++ b/workflow/03-architecture.md
@@ -1,0 +1,180 @@
+# Architecture
+
+## Repository Structure
+
+```
+~/.claude/
+├── CLAUDE.md                           # The brain — all rules and workflows
+├── README.md                           # Documentation for humans
+├── settings.json                       # Deterministic enforcement — hooks & permissions
+├── .gitignore                          # What NOT to version control
+│
+├── agents/                             # Specialized agents with their own context
+│   ├── orchestrator.md                 # Project manager — delegates, never implements
+│   ├── sprint-executor.md              # Worker — implements a sprint in isolation
+│   └── code-reviewer.md               # Auditor — read-only, cannot modify code
+│
+├── skills/                             # Auto-invocable workflows
+│   ├── plan/                           # Planning and PRD generation
+│   │   ├── SKILL.md                    # Planning workflow
+│   │   ├── correctness-discovery.md    # 6-question correctness framework
+│   │   ├── prd-template-minimal.md     # Minimal PRD template (Standard mode)
+│   │   ├── prd-template-full.md        # Full PRD template (PRD+Sprint mode)
+│   │   └── sprint-spec-template.md     # Sprint specification template
+│   ├── plan-build-test/                # Full local pipeline
+│   │   └── SKILL.md
+│   ├── ship-test-ensure/               # Deploy pipeline
+│   │   └── SKILL.md
+│   ├── compound/                       # Post-task learning capture
+│   │   └── SKILL.md
+│   └── workflow-audit/                 # Periodic system self-review
+│       └── SKILL.md
+│
+├── hooks/                              # Deterministic enforcement scripts
+│   ├── block-dangerous.sh              # Blocks destructive commands
+│   ├── post-edit-quality.sh            # Auto-formats code after edits
+│   ├── end-of-turn-typecheck.sh        # Type-checks TypeScript at end of turn
+│   ├── compound-reminder.sh            # Blocks session end without learning capture
+│   ├── proot-preflight.sh              # Environment checks for proot-distro
+│   ├── worktree-preflight.sh           # Git and dependency readiness
+│   └── retry-with-backoff.sh           # Utility for API rate limit handling
+│
+├── docs/                               # Reference material (loaded on demand)
+│   ├── evaluation-reference.md         # Quality evaluation checklists
+│   ├── anti-patterns-full.md           # 10 anti-patterns with examples and fixes
+│   ├── vague-requirements-translator.md
+│   ├── verification-gates.md           # 6 blocking verification gates
+│   ├── proot-distro-environment.md     # proot-distro ARM64 guide
+│   └── project-claude-md-template.md   # Template for project-specific CLAUDE.md
+│
+├── workflow/                           # This documentation
+│
+└── evolution/                          # Cross-project learning data
+    ├── error-registry.json             # Error patterns across projects
+    ├── model-performance.json          # Model success rate tracking
+    ├── workflow-changelog.md           # System evolution history
+    └── session-postmortems/            # Structured post-session analysis
+```
+
+## The Five Layers
+
+Each layer of the repository serves a distinct purpose with a specific enforcement model:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     CLAUDE.md                           │
+│              The Constitution — fundamental rules       │
+│         (loaded every session, costs context tokens)    │
+├─────────────────────────────────────────────────────────┤
+│                    settings.json                        │
+│          The Police — deterministic enforcement         │
+│              (hooks run as real code)                   │
+├─────────────────────────────────────────────────────────┤
+│                      agents/                            │
+│         Specialized Workers — each with own role        │
+│          (own context window, permissions, model)       │
+├─────────────────────────────────────────────────────────┤
+│                      skills/                            │
+│        Operating Procedures — step-by-step workflows    │
+│           (auto-invoked based on conversation)          │
+├─────────────────────────────────────────────────────────┤
+│                       docs/                             │
+│          Reference Library — consulted on demand        │
+│          (not loaded every session — saves context)     │
+├─────────────────────────────────────────────────────────┤
+│                     hooks/                              │
+│         Enforcement Scripts — hard/soft blockers        │
+│          (bash scripts, run before/after actions)       │
+├─────────────────────────────────────────────────────────┤
+│                    evolution/                           │
+│        System Memory — cross-project learning           │
+│           (error patterns, model performance)           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Layer Responsibilities
+
+### Layer 1: CLAUDE.md (The Constitution)
+
+- **What:** ~650 lines of rules, workflows, judgment protocols, and development standards
+- **When loaded:** Every session start (costs context tokens)
+- **Enforcement:** Probabilistic — the model "should" follow these rules but can deviate
+- **Design rule:** Keep it dense and essential. If something can live in `docs/`, move it there
+
+### Layer 2: settings.json + hooks/ (The Police)
+
+- **What:** Shell scripts that run as hooks at specific lifecycle points
+- **When loaded:** Every tool use (PreToolUse), every edit (PostToolUse), every session end (Stop)
+- **Enforcement:** Deterministic — code runs regardless of what the model thinks
+- **Design rule:** The model cannot bypass a hook. Use hooks for rules that must never be broken
+
+### Layer 3: agents/ (The Workers)
+
+- **What:** Specialized agents with their own context window, tools, model, and permissions
+- **When loaded:** When spawned by the orchestrator or skills
+- **Enforcement:** Tool-level — each agent only has access to specific tools
+- **Design rule:** Principle of Least Privilege — give each agent only what it needs
+
+### Layer 4: skills/ (The Procedures)
+
+- **What:** Step-by-step workflows that auto-invoke based on conversation context
+- **When loaded:** When triggered by user intent or explicit `/skill-name` command
+- **Enforcement:** Process — skills define the order of operations
+- **Design rule:** Skills never hardcode project details — they read from Execution Config
+
+### Layer 5: docs/ (The Library)
+
+- **What:** Detailed reference material for specific topics
+- **When loaded:** On demand, when a skill or agent references them
+- **Enforcement:** None — purely informational
+- **Design rule:** Save context by keeping detailed content here, not in CLAUDE.md
+
+### Layer 6: evolution/ (The Memory)
+
+- **What:** Cross-project learning data — error patterns, model performance, system changelog
+- **When loaded:** During `/compound` and `/workflow-audit`
+- **Enforcement:** Adaptive — data drives model selection and rule creation
+- **Design rule:** Capture everything, analyze periodically, promote proven patterns
+
+## What Gets Version Controlled
+
+The `.gitignore` reveals an important decision about what is **shared system** vs. **ephemeral state**:
+
+**Versioned (the system):**
+- `CLAUDE.md`, `settings.json`, `README.md`
+- `agents/`, `skills/`, `hooks/`, `docs/`
+- `evolution/` (error-registry, model-performance, changelog)
+
+**Not versioned (the state):**
+- `.state/`, `projects/`, `backups/`, `cache/`, `history.jsonl`
+- `worktrees/` (temporary directories for parallel execution)
+- `settings.local.json` (machine-specific overrides)
+- `todoStorage.json`, `*.log`, `plans/`, `tasks/`, `telemetry/`
+
+The key decision: **version the system (rules, agents, skills, hooks), not the state (cache, history, temporary data)**. This allows cloning the repository on any new machine and having the system work immediately.
+
+## How the Layers Interact
+
+```
+User says: "I need to add OAuth login"
+
+1. CLAUDE.md classifies this as PRD+Sprint mode
+2. /plan skill auto-invokes (Layer 4)
+3. Contract-First pattern runs (Layer 1 rule)
+4. Correctness Discovery questions asked (Layer 4 references Layer 5)
+5. PRD created, sprints extracted (Layer 4)
+6. /plan-build-test spawns orchestrator agent (Layer 3)
+7. Orchestrator spawns sprint-executor agents in worktrees (Layer 3)
+8. block-dangerous.sh prevents any destructive commands (Layer 2)
+9. post-edit-quality.sh auto-formats every edit (Layer 2)
+10. End-of-turn typecheck catches type errors (Layer 2)
+11. /compound captures learnings (Layer 4)
+12. Error patterns saved to evolution/ (Layer 6)
+13. compound-reminder.sh blocks session end without learnings (Layer 2)
+```
+
+Every layer plays its part. The system works because no single layer is responsible for everything.
+
+---
+
+Next: [The Constitution (CLAUDE.md)](04-constitution.md)

--- a/workflow/04-constitution.md
+++ b/workflow/04-constitution.md
@@ -1,0 +1,140 @@
+# The Constitution — CLAUDE.md
+
+The `CLAUDE.md` is the most important file in the repository. It is loaded automatically at the start of every session and functions as the "operating system" of the agent. This document explains its key sections.
+
+## Value Hierarchy
+
+When two values conflict, which one wins? The system defines a clear priority:
+
+```
+Priority 1 ★★★★★  Security & Privacy
+                   Auth integrity, data masking, secrets management — non-negotiable
+
+Priority 2 ★★★★☆  Functional Correctness
+                   Code that works correctly > code that looks elegant
+
+Priority 3 ★★★☆☆  Robustness
+                   For core components: defensive coding, error handling, validation
+
+Priority 4 ★★☆☆☆  Iteration Speed
+                   For UI, prototypes, non-core features: ship fast, iterate later
+
+Priority 5 ★☆☆☆☆  Performance
+                   Optimize only when measured data shows a bottleneck
+```
+
+**Why this matters:** AI agents frequently need to make decisions where two values conflict. "Should I add extra validation on this endpoint (robustness) or ship quickly (speed)?" If it's a payment endpoint, robustness wins (priority 3 > 4). If it's a UI prototype, speed wins (priority 4 > 5). Without this explicit hierarchy, the agent would make arbitrary choices.
+
+## Autonomous Decision Authority
+
+The system divides decisions into three categories:
+
+| Agent CAN Decide Alone | Agent MUST Ask User | Agent NEVER Does |
+|---|---|---|
+| Variable/function naming | Schema/API changes | Expose sensitive data in logs |
+| Choice between equivalent approaches | New dependency outside existing stack | Delete passing tests |
+| Implementation order within a phase | Architectural pattern change | Deploy to production |
+| CSS/styling decisions | Remove existing functionality | Modify auth/permission config |
+| Test structure and naming | Security/privacy tradeoffs | Bypass rate limiting or validation |
+| Refactoring within a single file | Scope significantly larger than expected (>2x) | Silently swallow errors |
+
+**Why this table matters:** It solves the fundamental dilemma of AI agents — autonomy vs. safety. If the agent asks about everything, it's slow and annoying. If it decides everything on its own, it can cause damage. This table defines the exact boundary.
+
+The "NEVER" column exists because certain actions are **never justified at any confidence level**. Even if the agent is 99% sure deleting a test is correct, it doesn't have permission.
+
+## Tradeoff Resolution by Deliverable
+
+What to optimize depends on what is being built:
+
+| Deliverable | Optimize For | Acceptable to Sacrifice |
+|---|---|---|
+| API endpoint | Security, validation, idempotency | Development speed |
+| UI component | UX, responsiveness, accessibility | Marginal performance |
+| Data pipeline | Correctness, observability | Code elegance |
+| Documentation | Clarity, accuracy | Completeness |
+| Prototype/POC | Speed, core functionality | Tests, edge cases |
+
+This prevents the agent from applying the same rigor to everything. A prototype does not need 100% test coverage. A payment endpoint cannot skip validation.
+
+## Escalation Logic
+
+The agent MUST stop and ask when:
+
+1. The task is ambiguous and there are 2+ reasonable interpretations
+2. The proposed solution conflicts with an existing ADR or pattern
+3. Actual scope is significantly larger than expected (>2x)
+4. An unrelated bug is discovered during implementation
+5. The decision falls in the "MUST ask" column
+6. No relevant documentation exists for the area being modified
+7. A dependency or external service behaves unexpectedly
+
+When escalating, the agent uses a standardized format:
+
+```
+[DECISION NEEDED]
+Context: [brief].
+Option A: [X].
+Option B: [Y].
+My recommendation: [A/B], because [reason].
+Proceed?
+```
+
+This format forces the agent to synthesize the context, show it already analyzed options, and give a recommendation — saving the human's time.
+
+## Confidence Levels
+
+| Level | Meaning | Action |
+|---|---|---|
+| HIGH | Clear pattern in docs/solutions, existing tests confirm | Proceed autonomously |
+| MEDIUM | Inferred from code but no explicit docs | Proceed but document assumption |
+| LOW | Multiple valid interpretations, no precedent | STOP and ask user |
+
+## Risk Categories
+
+| Area | Catastrophic (rollback immediately) | Tolerable (fix forward) |
+|---|---|---|
+| Auth/Security | Any bypass, data leak, permission escalation | Error message copy, UI polish |
+| Data/API | Data loss, schema break, contract violation | Response format, non-critical field |
+| UI | Crash, blank page, broken critical flow | Pixel imperfection, animation glitch |
+| Tests | Deleting passing tests, making tests lie | Flaky new test, missing edge case |
+| Infrastructure | Broken deploy, env leak, service outage | Config optimization, log level |
+
+## Development Rules
+
+### TDD for Features (mandatory order)
+
+```
+1. Write unit tests first → 2. Implement code → 3. Integration tests → 4. E2E tests → 5. Run ALL tests
+```
+
+### TDD for Bug Fixes (different order)
+
+```
+1. REPRODUCE → 2. INVESTIGATE → 3. FIX → 4. VERIFY → 5. REGRESS
+   Write failing    Find root       Target    Confirm     Add regression
+   test             cause           root      test now    tests
+                                    cause     passes
+```
+
+### Rollback & Recovery
+
+When a fix makes things worse, **stop layering fixes on top of broken fixes**:
+
+1. **Revert** to last known working state
+2. **Reassess** with fresh eyes
+3. **Try a different approach** — if same approach failed twice, it's wrong
+4. **Escalate to user** after 2+ distinct failed approaches
+
+### Post-Implementation Checklist
+
+- All tests passing
+- No unused components, imports, or dead code
+- No console.logs or debug code
+- No duplicated code
+- Descriptive variable/function names
+- Security check
+- Performance check
+
+---
+
+Next: [Workflow & Modes](05-workflow-and-modes.md)

--- a/workflow/05-workflow-and-modes.md
+++ b/workflow/05-workflow-and-modes.md
@@ -1,0 +1,205 @@
+# Workflow & Modes
+
+## The Three Execution Modes
+
+The system defines three modes, and the golden rule is: **switch modes freely within a single task**.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    EXECUTION MODES                       │
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│  QUICK FIX                                               │
+│  When: Single file, <30 lines, no architectural impact   │
+│  Process: Fix directly, run tests, micro-compound        │
+│  Spec: Intent Doc (4 lines)                              │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ Task → Fix → Test → "Would the system catch      │    │
+│  │                      this next time?"             │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                          │
+│  STANDARD                                                │
+│  When: Multi-file, clear scope, moderate complexity      │
+│  Process: Contract-First → 2 Correctness Questions       │
+│           → Minimal PRD → Implement → Verify → Compound  │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ Intent → Mirror → Receipt → PRD → Build → Test   │    │
+│  │ → Compound                                        │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                          │
+│  PRD + SPRINT                                            │
+│  When: Large feature, multi-component, >1h agent work    │
+│  Process: Contract-First → 6 Correctness Questions       │
+│           → Full PRD → Sprint Decomposition → Compound   │
+│  ┌──────────────────────────────────────────────────┐    │
+│  │ Intent → Mirror → Receipt → Full PRD             │    │
+│  │ → Sprint 1 → Sprint 2 → ... → Sprint N          │    │
+│  │ → Verify → Compound                              │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+Typical pattern within a large task: start in PRD+Sprint (plan), drop to Standard for normal sprints, drop to Quick Fix for trivial adjustments, return to Standard for the next piece.
+
+**Why this matters:** Different tasks need different levels of ceremony. Using a full PRD for a CSS fix is bureaucracy. Using Quick Fix for a payment system is reckless. Mode fluency means matching the process to the complexity.
+
+## Contract-First Pattern
+
+Mandatory for Standard and PRD+Sprint modes. Before executing any multi-step task:
+
+```
+  Human                          Agent
+    │                              │
+    │  "I want feature X"          │
+    ├─────────────────────────────►│
+    │                              │  ┌─────────────────────┐
+    │                              │  │ 1. INTENT           │
+    │                              │  │    (user describes)  │
+    │                              │  └─────────────────────┘
+    │                              │
+    │  "I understand you want:     │
+    │   - Feature X                │
+    │   - With constraint Y        │
+    │   - Tradeoff: prefer Z"      │
+    │◄─────────────────────────────┤
+    │                              │  ┌─────────────────────┐
+    │                              │  │ 2. MIRROR           │
+    │                              │  │    (agent reflects)  │
+    │                              │  └─────────────────────┘
+    │                              │
+    │  "Yes, but also add W"       │
+    ├─────────────────────────────►│
+    │                              │  ┌─────────────────────┐
+    │                              │  │ 3. RECEIPT          │
+    │                              │  │    (user confirms)   │
+    │                              │  └─────────────────────┘
+    │                              │
+    │                              │  ┌─────────────────────┐
+    │                              │  │ EXECUTION BEGINS    │
+    │                              │  └─────────────────────┘
+```
+
+**Why this matters:** The biggest waste in AI engineering is not bad code — it's **building the wrong thing**. When an agent misinterprets a requirement and implements 500 lines in the wrong direction, all that work is thrown away. Contract-First prevents this by spending 2 minutes on alignment to save hours of rework.
+
+## Correctness Discovery
+
+Six questions must be answered before writing any PRD:
+
+| # | Question | Purpose | Example |
+|---|----------|---------|---------|
+| 1 | **Audience:** Who uses this output? | Defines who you're building for | "End users on pricing page" |
+| 2 | **Failure:** What makes it useless? | Defines the quality floor | "Showing outdated prices" |
+| 3 | **Danger:** What makes it harmful? | Identifies risks beyond "useless" | "Showing prices lower than actual" |
+| 4 | **Uncertainty:** What to do when uncertain? | Sets the safety level | Guess / Flag / Stop |
+| 5 | **Risk:** What's worse — wrong answer or refusal? | Calibrates error tolerance | Security: block. UX: show something. |
+| 6 | **Verification:** How to check correctness? | Forces completeness | "E2E test of complete login flow" |
+
+In Standard mode, only questions 1 and 6 are asked. In PRD+Sprint mode, all 6 are mandatory.
+
+## The Autonomous Pipeline
+
+The preferred end-to-end workflow minimizes human touchpoints:
+
+```
+┌─────────┐    ┌──────────────────┐    ┌──────────────────────┐    ┌───────────┐
+│  /plan   │───►│ User reviews PRD │───►│  /plan-build-test    │───►│ User tests│
+│          │    │ and approves     │    │  (autonomous)        │    │ manually  │
+└─────────┘    └──────────────────┘    └──────────────────────┘    └─────┬─────┘
+                                                                         │
+                ┌──────────────────────────────────────────────────────────┘
+                │
+                ▼
+        ┌───────────────────┐    ┌──────────────────────┐    ┌──────────────┐
+        │ /ship-test-ensure │───►│ MANDATORY: User       │───►│ Production   │
+        │ (autonomous thru  │    │ confirms prod deploy  │    │ + Lighthouse │
+        │  staging)         │    │ (non-negotiable gate) │    │ 100/100      │
+        └───────────────────┘    └──────────────────────┘    └──────────────┘
+```
+
+**Design goal:** The user reviews the plan once, approves once, tests manually once, and confirms production deploy once. Everything else runs without interruption.
+
+### Autonomous Checkpoints
+
+| Checkpoint | Autonomous Action | Rationale |
+|---|---|---|
+| Execution plan | Auto-select "Run all autonomously" | PRD was already reviewed |
+| Verification failures | Exhaust retry budget, then BLOCKED | User checks at end |
+| Fresh context check | Auto-select "Continue here" | Advisory only |
+| Deploy timeout (15min) | Wait 10 more minutes, then BLOCKED | Safe default |
+| **Production deploy** | **ALWAYS ask user** | **Non-negotiable safety gate** |
+| Lighthouse plateau | Accept current scores after max iterations | Performance, not correctness |
+| **Rollback decision** | **ALWAYS ask user** | **Destructive action needs human judgment** |
+
+## Skill Selection Decision Tree
+
+```
+"What do I need to do?"
+│
+├─ "Just plan, don't build yet"
+│   └─ /plan
+│
+├─ "Build a feature / fix a bug / implement something"
+│   ├─ Single file, < 30 lines, obvious fix?
+│   │   └─ Quick Fix (no skill needed)
+│   └─ Anything larger
+│       └─ /plan-build-test
+│
+├─ "Ship what I've built to production"
+│   └─ /ship-test-ensure
+│
+├─ "Full autonomous pipeline"
+│   └─ /plan → review PRD → /plan-build-test → manual test → /ship-test-ensure
+│
+├─ "Wrap up / capture what I learned"
+│   └─ /compound
+│
+├─ "I have pending task files from a previous session"
+│   └─ /plan-build-test (Phase 0 detects and resumes)
+│
+└─ "Audit how the workflow is performing"
+    └─ /workflow-audit
+```
+
+## Knowledge Promotion Chain
+
+Knowledge flows upward in an ascending chain:
+
+### Per-Project Promotion
+
+```
+session-learnings (ephemeral — lives during session)
+    │
+    ▼  Pattern proves useful in 2+ tasks
+docs/solutions/ (project knowledge — persistent)
+    │
+    ▼  Affects architecture
+ADRs (Architecture Decision Records — formal & durable)
+    │
+    ▼  Improves the workflow itself
+CLAUDE.md updates (system-level changes)
+```
+
+### Cross-Project Promotion
+
+```
+session-learnings
+    │
+    ▼  Error occurs
+~/.claude/evolution/error-registry.json (cross-project error patterns)
+    │
+    ▼  Model performance recorded
+~/.claude/evolution/model-performance.json (success rate tracking)
+    │
+    ▼  Pattern confirmed in 2+ projects
+~/.claude/projects/-root/memory/ (cross-project memory)
+    │
+    ▼  System file updated
+~/.claude/evolution/workflow-changelog.md (evolution history)
+```
+
+The analogy is the immune system: an infection (bug) is fought locally (session-learnings), but if the same type appears repeatedly, the body develops permanent antibodies (CLAUDE.md update or hook).
+
+---
+
+Next: [Sprint System](06-sprint-system.md)

--- a/workflow/06-sprint-system.md
+++ b/workflow/06-sprint-system.md
@@ -1,0 +1,203 @@
+# Sprint System
+
+## What Are Sprints?
+
+For large PRDs, work is decomposed into **Sprints** — self-contained units designed for one agent in a healthy context window. Each sprint can be independently verified and should produce a working state.
+
+## Sprint Rules
+
+1. Each Sprint **MUST be independently verifiable** (own acceptance criteria and tests)
+2. Each Sprint **SHOULD produce a working state** (builds and passes tests)
+3. Ordered by dependency (N+1 may depend on N, never reverse)
+4. Target size: **30-90 minutes** of agent work. Larger: decompose further
+5. Maximum **5 sprints per PRD**. If more needed: split the PRD
+6. Each sprint is **extracted into its own spec file** (not inline in the PRD)
+7. Sprint agents load **ONLY their sprint spec file** — never the full PRD
+
+### Why These Limits Exist
+
+**Context Window:** AI models have a maximum number of tokens they can process. The longer the conversation, the more the model "forgets" earlier instructions — a phenomenon called "context rot." Sprints of 30-90 minutes keep context healthy.
+
+**5 Sprint Limit:** Guards against the "Kitchen Sink" anti-pattern — stuffing everything into one monstrous PRD. If you need more than 5 sprints, the work is too large for a single PRD and should be split by independent deliverable.
+
+## Sprint File Structure
+
+```
+docs/tasks/<area>/<category>/YYYY-MM-DD_HHmm-name/
+├── spec.md                     # The PRD itself
+├── progress.json               # Sprint tracking state
+└── sprints/
+    ├── 01-setup-auth.md        # Sprint 1 spec (self-contained)
+    ├── 02-login-ui.md          # Sprint 2 spec (self-contained)
+    └── 03-route-protection.md  # Sprint 3 spec (self-contained)
+```
+
+## File Boundaries
+
+Each sprint spec declares **file boundaries** — which files it creates, modifies, reads, and shares:
+
+```
+files_to_create:    [new files this sprint builds]
+files_to_modify:    [existing files this sprint can touch]
+files_read_only:    [files to reference but NOT modify]
+shared_contracts:   [interfaces/types shared across sprints]
+```
+
+**Why file boundaries matter:** If two sprints both modify `src/app/layout.tsx`, they cannot run in parallel — their changes would conflict. File boundaries make this explicit during planning, before any code is written.
+
+## Sprint Spec Template
+
+Each sprint gets its own file:
+
+```markdown
+## Meta
+Sprint: N | Batch: M | Model: sonnet | Depends on: [list]
+
+## Objective
+[One sentence describing what this sprint accomplishes]
+
+## File Boundaries
+files_to_create: [list]
+files_to_modify: [list]
+files_read_only: [list]
+shared_contracts: [list]
+
+## Tasks
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Verification
+[Specific commands to run]
+
+## Context
+[Relevant details from PRD — NOT the entire PRD]
+
+## Agent Notes (filled by executor)
+### Decisions Made
+### Assumptions
+### Issues Found
+```
+
+## Progress Tracking (progress.json)
+
+The orchestrator tracks sprint state with `progress.json`:
+
+```json
+{
+  "sprints": [
+    {
+      "id": "01-setup-auth",
+      "status": "complete",
+      "batch": 1,
+      "depends_on": [],
+      "started_at": "2026-03-14T14:00:00Z",
+      "completed_at": "2026-03-14T14:45:00Z"
+    },
+    {
+      "id": "02-login-ui",
+      "status": "in_progress",
+      "batch": 2,
+      "depends_on": ["01-setup-auth"],
+      "started_at": "2026-03-14T14:50:00Z"
+    },
+    {
+      "id": "03-route-protection",
+      "status": "pending",
+      "batch": 2,
+      "depends_on": ["01-setup-auth"]
+    }
+  ]
+}
+```
+
+Status values: `pending` → `in_progress` → `complete` or `blocked`
+
+## Batch Planning
+
+Sprints are grouped into **batches** based on dependencies:
+
+```
+Batch 1:  Sprint 1 (no dependencies — runs first)
+          │
+          ▼
+Batch 2:  Sprint 2 + Sprint 3 (both depend on Sprint 1, but not on each other)
+          │              │
+          ▼              ▼
+          (run in parallel — different files)
+```
+
+**Rules for batching:**
+1. Analyze tasks for file overlap and dependencies
+2. **DEPENDENT** if: same files, same component tree, shared config, output feeds another
+3. **INDEPENDENT** if: different files/dirs, unrelated features, no shared deps
+4. When in doubt, run sequentially — safe > fast
+
+## PRD Templates
+
+### Minimal PRD (Standard Mode)
+
+```markdown
+# [Task Title]
+
+## What & Why
+**Problem:** [What is wrong or missing]
+**Desired Outcome:** [What success looks like]
+
+## Correctness Contract
+**Audience:** [Who uses this output]
+**Verification:** [How to check correctness]
+
+## Acceptance Criteria
+- [ ] [Binary testable condition 1]
+- [ ] [Binary testable condition 2]
+
+## Non-Goals / Boundaries
+- [What this task will NOT do]
+
+## If Uncertain
+[Default policy: Guess / Flag / Stop]
+
+## Verification
+- [ ] [Specific test/lint/typecheck command]
+
+## Implementation
+- [ ] [Step 1]
+- [ ] [Step 2]
+
+## Learnings (filled after completion)
+```
+
+### Full PRD (PRD+Sprint Mode)
+
+Adds to the minimal template:
+- **Justification** — Why this is worth doing now
+- **Failure/Danger definitions** — What makes output useless or harmful
+- **Risk Tolerance** — Confident wrong or refusal?
+- **Success Metrics** — Current values and targets
+- **User Stories** — GIVEN/WHEN/THEN format
+- **Shared Contracts** — Interfaces/types shared across sprints
+- **Technical Constraints** — Stack, architecture, performance, security
+- **Open Questions** — Known unknowns
+- **Sprint Decomposition** — Table of sprints with dependencies and models
+
+Full templates are in `~/.claude/skills/plan/prd-template-minimal.md` and `prd-template-full.md`.
+
+## Why Each PRD Field Exists
+
+| Field | Purpose |
+|---|---|
+| **What & Why** | Problem before solution. If you can't articulate the problem, you shouldn't be building |
+| **Correctness Contract** | Defines "correct" before implementation |
+| **Acceptance Criteria** | Binary conditions (pass/fail). If you can't write a test for it, it's not valid |
+| **Non-Goals** | As important as goals. Prevents scope creep |
+| **Verification** | If you can't describe how to verify, the spec is incomplete |
+| **Learnings** | Filled after completion. Entry point for the Compound step |
+
+---
+
+Next: [Agents](07-agents.md)

--- a/workflow/07-agents.md
+++ b/workflow/07-agents.md
@@ -1,0 +1,228 @@
+# Agents
+
+Agents are specialized workers that live in `~/.claude/agents/`. Each has its **own context window**, tool permissions, model, and system prompt. They follow the **Principle of Least Privilege** — each agent has only the permissions necessary for its role.
+
+## Architecture Overview
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│                        ORCHESTRATOR                               │
+│  Model: sonnet  |  Tools: ALL (including Agent)                  │
+│  Role: Delegates, coordinates, merges. NEVER implements.          │
+│  Context: System instructions + progress.json + agent summaries  │
+│                                                                   │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
+│  │ SPRINT-EXECUTOR │  │ SPRINT-EXECUTOR │  │  CODE-REVIEWER  │  │
+│  │ Model: sonnet   │  │ Model: sonnet   │  │  Model: sonnet  │  │
+│  │ Tools: R/W/E/B  │  │ Tools: R/W/E/B  │  │  Tools: R only  │  │
+│  │ Isolation:      │  │ Isolation:      │  │  Cannot modify   │  │
+│  │ worktree        │  │ worktree        │  │  any files       │  │
+│  └─────────────────┘  └─────────────────┘  └─────────────────┘  │
+│                                                                   │
+│         Sprint 1              Sprint 2          Post-merge        │
+│       (own branch)          (own branch)        review            │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## Agent Frontmatter
+
+Each agent file begins with a YAML block defining its properties:
+
+```yaml
+---
+name: sprint-executor
+description: >
+  Executes a single sprint from a sprint spec file...
+model: sonnet
+tools: Read, Write, Edit, Bash, Glob, Grep
+isolation: worktree
+permissionMode: default
+maxTurns: 200
+---
+```
+
+| Property | Purpose |
+|---|---|
+| `name` | Unique identifier |
+| `description` | When and how to invoke (Claude Code uses this for automatic selection) |
+| `model` | Which Claude model to use (haiku/sonnet/opus) |
+| `tools` | Available tools (Principle of Least Privilege) |
+| `isolation` | `worktree` creates an isolated working directory with its own Git branch |
+| `maxTurns` | Maximum interactions the agent can make |
+
+## Agent Comparison
+
+| Agent | Model | Tools | Why This Model | Why These Tools |
+|---|---|---|---|---|
+| orchestrator | sonnet | ALL + Agent | Follows deterministic checklist; opus reserved for merge conflicts >3 files | Needs to spawn/manage other agents |
+| sprint-executor | sonnet | Read, Write, Edit, Bash, Glob, Grep | Good cost-benefit for implementation work | Needs to write code but NOT delegate |
+| code-reviewer | sonnet | Read, Grep, Glob | Read-only analysis | ONLY read — reviewer must report, not fix |
+
+## The Orchestrator
+
+The orchestrator is the most important agent. It follows a **deterministic checklist** — it is a workflow engine, not a strategist.
+
+### The 11-Step Protocol
+
+```
+Step 0:  Preflight
+         ├── Git readiness (init if needed)
+         ├── Working tree hygiene (dirty → snapshot commit)
+         ├── Stale worktree cleanup
+         ├── proot-distro detection
+         └── Dependency baseline
+
+Step 1:  Read progress.json + project CLAUDE.md
+
+Step 2:  Load sprint spec files, validate file boundaries
+
+Step 3:  Update progress.json → "in_progress"
+
+Step 4:  Spawn sprint-executor agents
+         (parallel for independent sprints, sequential for dependent)
+
+Step 5:  Collect structured results from executors
+
+Step 6:  Merge (for parallel batches)
+         ├── Sequential merge (lowest sprint number first)
+         ├── Conflict resolution (≤3 files: direct, >3: opus agent)
+         ├── Post-merge test suite
+         ├── File boundary validation
+         ├── Worktree cleanup
+         └── Code review (spawn code-reviewer agent)
+
+Step 7:  Coherence check (full test suite)
+
+Step 8:  Dev server smoke test (content-verified, not just HTTP 200)
+
+Step 8.5: Plan completeness audit (re-read specs, cite evidence)
+
+Step 9:  Update progress.json → "complete" or "blocked"
+
+Step 10: Return structured report with metrics
+```
+
+### What the Orchestrator NEVER Does
+
+- Implement code directly (delegates to sprint-executor)
+- Read the full PRD (sprint spec files are self-contained)
+- Make strategic decisions about sprint ordering (progress.json has the plan)
+- Modify session-learnings (the caller does that)
+- Proceed to the next batch (returns to caller for fresh context)
+- Accept "environment limitation" as reason to skip dev server test
+
+**One orchestrator invocation = one batch.** After completing its batch, it returns control. The caller spawns the next orchestrator for the next batch, ensuring fresh context.
+
+### Why Sonnet (Not Opus)
+
+The orchestrator follows a deterministic checklist, not open-ended reasoning. It reads progress.json, finds the next batch, spawns agents, collects results, merges. This doesn't require the most powerful model. Opus is reserved for merge conflict resolution (>3 files) where genuine reasoning is needed.
+
+## The Sprint Executor
+
+The sprint-executor receives a spec and implements it within an isolated worktree.
+
+### Key Characteristics
+
+- Runs in **isolated worktree** — own branch and directory
+- Has `maxTurns: 200` — can iterate extensively
+- Does NOT have the `Agent` tool — cannot delegate
+- Does NOT run dev server or E2E (integration concerns handled by orchestrator)
+
+### Protocol
+
+```
+Step 0:  Worktree bootstrap (verify deps, set proot env)
+
+Step 1:  Parse sprint spec
+         ├── Extract objective, file boundaries, tasks, criteria
+         ├── ONLY create files in files_to_create
+         ├── ONLY modify files in files_to_modify
+         └── Out-of-boundary needs: log in Agent Notes, do NOT modify
+
+Steps 2-6: Execute tasks one by one with TDD
+            ├── Update checkboxes IMMEDIATELY after each task
+            └── If task fails: retry 3x, then mark BLOCKED
+
+Step 7:  Fill Agent Notes (decisions, assumptions, issues)
+
+Step 8:  Anti-Goodhart verification
+
+Step 9:  Sprint acceptance criteria
+
+Step 10: Full verification (build → lint → type-check → test)
+
+Step 11: SKIP dev server and E2E (orchestrator handles post-merge)
+
+Step 12: Plan Completeness Audit (MANDATORY last step)
+
+Step 13: Return structured summary
+```
+
+### Why Executors Skip Dev Server
+
+Sprint-executors work in isolated worktrees. Running a dev server per worktree would be redundant and wasteful. The orchestrator runs dev server verification after merging all sprints — testing the integrated code, which is what matters.
+
+## The Code Reviewer
+
+The code-reviewer is intentionally limited to **read-only** access.
+
+### Checklist
+
+1. **Correctness** — Does code match the spec?
+2. **Security** — Any auth bypass, data leak, unvalidated input?
+3. **Patterns** — Does new code follow existing project patterns?
+4. **Edge Cases** — Error paths handled? Null/empty/boundary inputs?
+5. **Tests** — Verify behavior or just output? Missing coverage?
+6. **Coherence** — Consistent with rest of codebase?
+
+### Output Format
+
+```
+Verdict: PASS / NEEDS CHANGES / BLOCKING ISSUES
+Findings: severity-coded (minor / should fix / must fix)
+```
+
+### Why Read-Only?
+
+A reviewer who can edit has incentive to "fix" instead of report. Forcing read-only means the reviewer reports and the executor (or another agent) fixes — separation of responsibilities.
+
+## Worktree Isolation
+
+Sprint agents use `isolation: worktree` in their frontmatter. Each gets its **own working copy** of the Git repository:
+
+```
+Main Repository
+├── main branch (orchestrator's territory)
+│
+├── Worktree 1: sprint/01-setup-auth
+│   └── Sprint-executor 1 works here
+│       (own branch, own directory, own files)
+│
+├── Worktree 2: sprint/02-login-ui
+│   └── Sprint-executor 2 works here
+│       (can run IN PARALLEL with executor 1)
+│
+└── After completion:
+    Orchestrator merges worktree branches → main
+    Worktrees auto-cleaned
+```
+
+### Why Worktrees?
+
+1. **Safe parallelism:** Independent sprints run simultaneously without interference
+2. **Easy rollback:** If a sprint goes wrong, discard the worktree and delete the branch
+
+## Context Budget Rules
+
+The main agent is an **orchestrator**, not a worker. Its context should contain only: system instructions + session learnings + subagent summaries + user messages.
+
+**Rules:**
+- If you need to read file contents or build output, delegate to a subagent
+- Every subagent prompt ends with: "Return a structured summary: [specify exact fields]"
+- Never ask a subagent to "return everything" — specify exact data points
+- Target 10-20 lines of actionable info per subagent result
+- Chain subagents: extract only relevant fields from agent A to pass to agent B
+
+---
+
+Next: [Skills Reference](08-skills-reference.md)

--- a/workflow/08-skills-reference.md
+++ b/workflow/08-skills-reference.md
@@ -1,0 +1,262 @@
+# Skills Reference
+
+Skills are auto-invocable workflows that live in `~/.claude/skills/`. Each skill has a `SKILL.md` file that defines the step-by-step procedure. Skills auto-invoke based on conversation context — you can also invoke them explicitly with `/skill-name`.
+
+## Pipeline Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          SKILL PIPELINE                                │
+│                                                                        │
+│    /plan              Generate PRD only. For when you want to plan     │
+│       │               without executing.                               │
+│       ▼                                                                │
+│    /plan-build-test   Smart entry point: discover tasks, plan if       │
+│       │               needed, execute with agent teams, verify         │
+│       │               locally. Runs autonomously by default.           │
+│       ▼                                                                │
+│    /ship-test-ensure  CI/CD pipeline: branch, PR, merge, staging      │
+│       │               E2E, production deploy, Lighthouse 100/100.      │
+│       │               Autonomous through staging; confirms before      │
+│       │               production.                                      │
+│       ▼                                                                │
+│    /compound          Post-task learning capture. Auto-invoked         │
+│       │               after completion. Cross-project knowledge        │
+│       │               promotion.                                       │
+│       ▼                                                                │
+│    /workflow-audit    Periodic self-review. Monthly or after 10+       │
+│                      sessions. Reviews model performance, error        │
+│                      patterns, rule staleness.                         │
+│                                                                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## /plan — Planning Only
+
+**Trigger:** User describes a new task, feature, bug, or says "plan", "let's build", "I need", "implement".
+
+**Output:** PRD file(s) at `docs/tasks/`. Does NOT execute — this skill produces the plan only.
+
+### Steps
+
+```
+Step 1: Classify mode
+        ├── Quick Fix → "No PRD needed"
+        ├── Standard → Minimal PRD
+        └── PRD+Sprint → Full PRD
+
+Step 2: Contract-First (mirror understanding, get confirmation)
+
+Step 3: Correctness Discovery (2 or 6 questions)
+
+Step 4: Write PRD at docs/tasks/<area>/<category>/YYYY-MM-DD_HHmm-name/spec.md
+
+Step 5: Spec Self-Evaluator
+        ├── Spawn SEPARATE haiku agent (different perspective)
+        ├── Score 14-point checklist
+        ├── Must score 11+/14 to proceed
+        └── Below 11: revise and re-evaluate
+
+Step 6: Extract sprint specs (if PRD+Sprint)
+        ├── Create sprints/ subdirectory
+        ├── One file per sprint with file boundaries
+        ├── Create progress.json
+        └── Validate: max 5 sprints, no file conflicts within batches
+
+Step 7: "PRD saved. Run /plan-build-test to execute."
+```
+
+**Key design decision:** A separate agent evaluates the spec. Using a separate agent prevents the author from grading their own homework — different context = more honest evaluation.
+
+---
+
+## /plan-build-test — The Local Pipeline
+
+The most extensive skill. Operates as a **Team Lead** coordinating specialist agents. **Autonomous by default.**
+
+### Phases
+
+```
+Phase 0: Resume Gate
+         ├── progress.json with pending sprints?  → Phase 3 (execute)
+         ├── All sprints complete?                → Phase 6 (learn)
+         ├── All sprints blocked?                 → Report to user
+         └── No progress.json?                    → Phase 1 (discover)
+
+Phase 1: Discovery
+         Spawn Explore agent (haiku) to find pending tasks
+
+Phase 2: Batch Planning
+         Analyze dependencies, assign models, auto-start
+
+Phase 3: Execution
+         For each batch:
+         ├── PRD+Sprint task → spawn orchestrator agent
+         │   (one per batch, fresh context)
+         ├── Simple task → spawn general-purpose agent
+         └── Inter-Batch Learning Loop:
+             Batch 1's mistakes → Batch 2's rules
+
+Phase 4: Post-Implementation
+         ├── Code review (code-reviewer agent)
+         └── Code simplification (code-simplifier plugin)
+
+Phase 5: Live Verification (MANDATORY — CANNOT BE SKIPPED)
+         ├── 5.1: Static verification (build, lint, types, tests)
+         ├── 5.2: Dev server startup (MANDATORY)
+         ├── 5.2.5: Runtime content verification
+         ├── 5.3: Route health check (ALL routes must return 200)
+         ├── 5.4: Playwright E2E tests
+         ├── 5.5: Task file audit (plan completeness re-read)
+         ├── 5.6: Regression scan
+         ├── 5.7: Handle failures (adaptive retries)
+         ├── 5.8: Kill dev server
+         └── 5.9: Final gate — verification summary
+              ALL items must show PASS to proceed
+
+Phase 6: Learning & Self-Improvement
+         ├── Persist to project knowledge files
+         ├── Update error-registry.json
+         ├── Update model-performance.json
+         ├── Write session postmortem
+         └── Generate session report
+```
+
+### The Inter-Batch Learning Loop
+
+Before spawning the next batch, the skill re-reads session learnings to include rules from previous batches in the next agents' prompts. This creates a **learning chain**: Batch 1's mistakes become Batch 2's prevention rules.
+
+---
+
+## /ship-test-ensure — Deploy Pipeline
+
+Takes code from "locally verified" to "production with perfect Lighthouse scores." **Autonomous through staging; confirms before production.**
+
+### Phases
+
+```
+Phase 0: Context & Config
+         Read Execution Config, detect changed apps, run local verification
+
+Phase 1: Commit, Branch & PR
+         ├── Capture PRE_DEPLOY_SHA (rollback point)
+         ├── Create feature branch (ship/YYYYMMDD-HHMM-desc)
+         ├── Stage specific files (never git add -A)
+         ├── Commit, push, create PR
+         ├── Wait for CI checks
+         └── Merge via squash merge
+
+Phase 2: Follow Staging Deploy
+         ├── Monitor GitHub Actions (30s poll, 15min timeout)
+         └── Max 3 retry cycles
+
+Phase 3: E2E on Staging
+         ├── Run E2E suite against staging URL
+         ├── Categorize failures: actual bugs vs flaky vs staging-specific
+         └── Max 5 fix-deploy-test cycles
+
+Phase 4: Production Deploy
+         ├── ★ MANDATORY USER CONFIRMATION ★
+         ├── Trigger production deploy commands
+         └── Monitor with same pattern as Phase 2
+
+Phase 5: PageSpeed & Lighthouse
+         ├── Test all configured pages (mobile + desktop)
+         ├── Classify: code-fixable / infrastructure / third-party
+         ├── Spawn fix agents
+         └── Max 5 iterations; plateau → accept current scores
+
+Phase 6: Final Report & Compound
+         ├── Final Lighthouse score table
+         ├── Core Web Vitals report
+         └── Rollback protocol (★ MANDATORY USER CONFIRMATION ★)
+```
+
+**Why CI/CD through PRs:** The system enforces PR workflow because: (1) CI checks run on the PR, (2) merge is auditable, (3) rollback is clean, (4) industry best practice.
+
+---
+
+## /compound — Learning Capture
+
+The shortest skill but conceptually the most important:
+
+### Steps
+
+```
+Steps 1-3: Review → Identify learnings → Update session-learnings
+
+Step 4:    Knowledge Promotion Chain
+           ├── Pattern repeats? → docs/solutions/
+           ├── Affects architecture? → propose ADR
+           ├── Workflow change? → propose CLAUDE.md update
+           ├── System Update Loop:
+           │   ├── Missing agent instructions → update agent file
+           │   ├── Missing hook → propose settings.json change
+           │   └── Skill gap → update skill file
+           └── Feedback Capture:
+               Mine user corrections from conversation
+               → error-registry + model-performance + system updates
+
+Step 5:    The Three Compound Questions
+           ├── "What was the hardest decision made here?"
+           ├── "What alternatives were rejected, and why?"
+           └── "What are we least confident about?"
+
+Steps 6-8: Cross-project promotion
+           ├── Update error-registry.json
+           ├── Update model-performance.json
+           ├── Promote to cross-project memory (if 2+ projects)
+           ├── Log in workflow-changelog.md
+           └── Write session postmortem
+
+Step 9:    Write completion marker
+```
+
+### Quick Fix Micro-Compound
+
+For trivial fixes, skip the full compound. Ask one question: "Would the system catch this automatically next time?" If no — add to error-registry or session-learnings.
+
+---
+
+## /workflow-audit — System Self-Review
+
+Periodic audit of the workflow system itself. Run monthly or after 10+ sessions.
+
+### Steps
+
+```
+Step 1: Load evolution data (error-registry, model-performance, changelog)
+
+Step 2: Error pattern analysis
+        ├── Frequency: which categories occur most?
+        ├── Recurrence: errors that keep happening despite fix?
+        ├── Resolution: % auto-preventable?
+        └── Cross-project: errors in 3+ projects?
+
+Step 3: Model performance analysis
+        ├── Success rate table per model per task type
+        ├── Upgrade candidates (<70% success with 10+ samples)
+        ├── Downgrade candidates (>90% — save cost)
+        └── Cost estimate for proposed changes
+
+Step 4: Rule staleness check
+        ├── List all rules (MUST, NEVER, ALWAYS)
+        ├── Flag rules >90 days old and never triggered
+        └── Check for contradictions
+
+Step 5: Changelog review
+        ├── Change velocity (0 = not learning, >10 = thrashing)
+        └── Regression check (any reverted changes?)
+
+Step 6: Session postmortem analysis
+
+Step 7: Generate audit report (health score 1-10)
+
+Step 8: Apply recommendations (with user approval only)
+```
+
+---
+
+Next: [Hooks & Enforcement](09-hooks-and-enforcement.md)

--- a/workflow/09-hooks-and-enforcement.md
+++ b/workflow/09-hooks-and-enforcement.md
@@ -1,0 +1,242 @@
+# Hooks & Enforcement
+
+## Why Hooks Exist
+
+```
+┌────────────────────────────────────────┐
+│            CLAUDE.md says:             │
+│  "Never use npm; use pnpm"            │
+│                                        │
+│  This is a SUGGESTION.                 │
+│  The model might ignore it.            │
+│  (LLMs are probabilistic)             │
+│                                        │
+├────────────────────────────────────────┤
+│          block-dangerous.sh:           │
+│  if [[ $COMMAND =~ npm ]]; then        │
+│    deny "Use pnpm instead"             │
+│  fi                                    │
+│                                        │
+│  This is ENFORCEMENT.                  │
+│  The model CANNOT bypass it.           │
+│  (Code is deterministic)              │
+└────────────────────────────────────────┘
+```
+
+While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json` implements **deterministic enforcement** via hooks. Instructions in CLAUDE.md are suggestions the model can ignore (LLMs are probabilistic). Hooks are real code that runs before/after every action. The model cannot bypass a hook.
+
+## Hook Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        HOOK LIFECYCLE                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  PreToolUse      │ ◄── Runs BEFORE every Bash command            │
+│  │  (Bash)          │     block-dangerous.sh: hard/soft blocks      │
+│  │                  │     proot-preflight.sh: environment warnings   │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  PostToolUse     │ ◄── Runs AFTER every Write/Edit/MultiEdit     │
+│  │  (Write|Edit|    │     post-edit-quality.sh: auto-format TS/JS   │
+│  │   MultiEdit)     │     (Biome → ESLint+Prettier → skip)          │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  Stop            │ ◄── Runs when the agent tries to end session  │
+│  │  (always)        │     end-of-turn-typecheck.sh: check TS types  │
+│  │                  │     compound-reminder.sh: BLOCK if compound   │
+│  │                  │     hasn't run after task completion           │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  Notification    │ ◄── Runs when agent needs user attention      │
+│  │  (always)        │     Desktop notification (notify-send)        │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  Exit codes:                                                        │
+│    0 = allow (continue normally)                                    │
+│    1 = error (hook itself failed)                                   │
+│    2 = BLOCK with message (agent receives the stderr message)       │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Hook Summary
+
+| Hook | Type | Trigger | Purpose | Blocking? |
+|---|---|---|---|---|
+| `block-dangerous.sh` | PreToolUse(Bash) | Every shell command | Block destructive operations | Hard/soft block |
+| `proot-preflight.sh` | PreToolUse(Bash) | First command/session | Warn about proot issues | No (informational) |
+| `post-edit-quality.sh` | PostToolUse(Write/Edit) | Every file edit | Auto-format TS/JS | Yes (exit 2 on lint errors) |
+| `end-of-turn-typecheck.sh` | Stop | End of turn | Type-check TypeScript | Yes (exit 2 on type errors) |
+| `compound-reminder.sh` | Stop | End of turn | Ensure /compound ran | Yes (exit 2 if skipped) |
+| `worktree-preflight.sh` | (orchestrator) | Sprint start | Git/env readiness | N/A (utility) |
+| `retry-with-backoff.sh` | (utility) | API calls | Exponential backoff | N/A (utility) |
+
+## PreToolUse: block-dangerous.sh
+
+Runs **before** every Bash command and implements three protection levels:
+
+### Hard Blocks (always denied, no override)
+
+- `rm -rf /` and variants (`rm -rf /*`, `rm -rf ~`, `rm -rf $HOME`)
+- `rm -rf .` in critical directories (/, home)
+- `rm -rf` on system directories (`/etc`, `/usr`, `/var`, `/bin`, etc.)
+- `chmod -R 777` on system paths
+- `dd if=` (raw disk operations)
+- Fork bombs
+
+### Soft Blocks (asks for re-approval)
+
+| Category | Blocked Commands | Why |
+|---|---|---|
+| Destructive git | `git push --force`, `git reset --hard`, `git checkout .`, `git restore .`, `git branch -D`, `git clean -f`, `git stash drop/clear` | Can destroy work irreversibly |
+| Push to main | `git push ... main/master` | Enforces PR workflow |
+| Wrong package manager | `npm install/run/exec/start/test/build/ci/init`, `npx` | Project uses pnpm exclusively |
+
+The hook uses pure bash regex matching (no subprocesses) for performance.
+
+## PostToolUse: post-edit-quality.sh
+
+Runs **after** every Write, Edit, or MultiEdit operation:
+
+```
+File edited
+    │
+    ▼
+Is it a TS/JS file? ─── No ──► skip
+    │
+   Yes
+    │
+    ▼
+Is it in an excluded dir? ─── Yes ──► skip
+(node_modules, dist, .next, etc.)
+    │
+   No
+    │
+    ▼
+Biome config exists? ─── Yes ──► biome check --write
+    │
+   No
+    │
+    ▼
+ESLint config exists? ─── Yes ──► eslint --fix + prettier --write
+    │
+   No
+    │
+    ▼
+skip (no linter found)
+```
+
+**Why this matters:** The agent never needs to remember to format code. Every edit is auto-formatted with zero cognitive overhead.
+
+## Stop Hook: end-of-turn-typecheck.sh
+
+When the agent tries to end a turn after writing code:
+
+```
+Agent wants to stop
+    │
+    ▼
+Was code written this turn? ─── No ──► allow stop
+    │
+   Yes
+    │
+    ▼
+Has tsconfig.json? ─── No ──► allow stop
+    │
+   Yes
+    │
+    ▼
+Find type checker (preference order):
+1. Native tsgo binary (cached path for speed)
+2. Global tsgo
+3. pnpm tsc --noEmit --skipLibCheck (fallback)
+    │
+    ▼
+Run type checker
+    │
+    ├─ Pass ──► allow stop
+    ├─ Fail ──► BLOCK (agent must fix types)
+    └─ Crash ──► fallback to tsc
+```
+
+## Stop Hook: compound-reminder.sh
+
+**BLOCKING** hook that prevents session end without learning capture:
+
+```
+Agent wants to stop
+    │
+    ▼
+Any progress.json with all sprints "complete"? ─── No ──► allow stop
+    │
+   Yes
+    │
+    ▼
+Was /compound run?
+    │
+    ├─ Yes ──► allow stop
+    └─ No ──► BLOCK
+             "Completed task detected but /compound hasn't run.
+              Run /compound to capture learnings, or dismiss to skip."
+```
+
+**Why this is the most important hook:** Without learning capture, the workflow never improves. The compound step is where the system transforms individual task experience into permanent system improvement. Making it blocking ensures it's never skipped.
+
+## settings.json Configuration
+
+```json
+{
+  "env": {
+    "ENABLE_LSP_TOOL": "1",
+    "NODE_OPTIONS": "--max-old-space-size=2048",
+    "CHOKIDAR_USEPOLLING": "true",
+    "WATCHPACK_POLLING": "true"
+  },
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "deny": []
+  },
+  "effortLevel": "high",
+  "skipDangerousModePermissionPrompt": true
+}
+```
+
+| Setting | Purpose |
+|---|---|
+| `ENABLE_LSP_TOOL` | Enables Language Server Protocol (goToDefinition, findReferences, etc.) |
+| `NODE_OPTIONS` | Increases Node.js memory limit (essential for proot-distro ARM64) |
+| `CHOKIDAR_USEPOLLING` / `WATCHPACK_POLLING` | Enables polling-based file watching |
+| `bypassPermissions` | Allows autonomous execution — compensated by hook safety |
+| `effortLevel: "high"` | Claude invests more tokens/reasoning in responses |
+
+## Adding Custom Hooks
+
+To add a new hook, add an entry to the relevant section in `settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/your-new-hook.sh \"$TOOL_INPUT\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Exit codes: `0` = allow, `1` = error, `2` = block with message (stderr).
+
+---
+
+Next: [Evolution & Learning](10-evolution-and-learning.md)

--- a/workflow/10-evolution-and-learning.md
+++ b/workflow/10-evolution-and-learning.md
@@ -1,0 +1,205 @@
+# Evolution & Learning
+
+## Why Evolution Exists
+
+Without cross-project learning, each project starts from scratch. The same mistakes are repeated, the same workarounds are rediscovered, and model assignments are never optimized. The evolution system makes the workflow **get better over time across all projects**.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    EVOLUTION DATA FLOW                          │
+│                                                                 │
+│  Project A                    Project B                         │
+│  ┌──────────┐                 ┌──────────┐                      │
+│  │ Session  │                 │ Session  │                      │
+│  │ learnings│                 │ learnings│                      │
+│  └────┬─────┘                 └────┬─────┘                      │
+│       │                            │                            │
+│       ▼                            ▼                            │
+│  ┌─────────────────────────────────────────┐                    │
+│  │      ~/.claude/evolution/               │                    │
+│  │                                         │                    │
+│  │  error-registry.json                    │ ◄── Error patterns │
+│  │  model-performance.json                 │ ◄── Model metrics  │
+│  │  workflow-changelog.md                  │ ◄── System changes │
+│  │  session-postmortems/                   │ ◄── Session data   │
+│  └────────────┬────────────────────────────┘                    │
+│               │                                                 │
+│               ▼                                                 │
+│  ┌─────────────────────────┐                                    │
+│  │  /workflow-audit        │ ◄── Monthly analysis               │
+│  │  (analyzes all data)    │                                    │
+│  └────────────┬────────────┘                                    │
+│               │                                                 │
+│               ▼                                                 │
+│  System improvements:                                           │
+│  - Model upgrades/downgrades                                    │
+│  - New hooks for recurring errors                               │
+│  - Updated CLAUDE.md rules                                      │
+│  - Skill/agent improvements                                     │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Error Registry (error-registry.json)
+
+A JSON database mapping error patterns to root causes, fixes, and projects where they occurred:
+
+```json
+{
+  "pattern": "error message or symptom regex",
+  "category": "ENV|LOGIC|CONFIG|DEPENDENCY|SECURITY|TEST|DEPLOY|PROOT|MERGE|PERFORMANCE",
+  "root_cause": "why it happens",
+  "fix": "how to fix it",
+  "auto_preventable": false,
+  "prevention": "hook/rule that prevents it",
+  "approaches_that_failed": [
+    { "approach": "what was tried", "why_bad": "why it didn't work" }
+  ],
+  "projects_seen": ["project-a", "project-b"],
+  "occurrences": 3
+}
+```
+
+The `approaches_that_failed` field is **negative learning** — recording what NOT to do is as valuable as recording what to do. When the same error appears in a future project, the agent knows both the fix AND which approaches to avoid.
+
+### Error Categories
+
+| Category | Examples |
+|---|---|
+| `ENV` | Missing env var, wrong Node version, proot limitation |
+| `LOGIC` | Wrong algorithm, off-by-one, race condition |
+| `CONFIG` | Bad setting, wrong flag, missing config file |
+| `DEPENDENCY` | Version mismatch, missing package, native module failure |
+| `SECURITY` | Auth bypass, data leak, XSS vulnerability |
+| `TEST` | Flaky test, wrong assertion, missing coverage |
+| `DEPLOY` | Failed deploy, wrong environment, broken pipeline |
+| `PROOT` | ARM64 limitation, broken symlink, memory issue |
+| `MERGE` | Conflict resolution error, file boundary violation |
+| `PERFORMANCE` | Slow query, large bundle, memory leak |
+
+## Model Performance (model-performance.json)
+
+Tracks success rates per model per task type, enabling data-driven model selection:
+
+```json
+{
+  "sonnet": {
+    "implementation": { "attempts": 25, "first_try_success": 20, "required_upgrade": 2 },
+    "bug_fix": { "attempts": 12, "first_try_success": 7, "required_upgrade": 3 }
+  }
+}
+```
+
+### Adaptation Rules (minimum 10 data points)
+
+- Success rate **< 70%** → propose upgrade (e.g., sonnet → opus)
+- Success rate **> 90%** → propose downgrade (e.g., sonnet → haiku, save cost)
+- Changes require user approval
+- Logged in workflow-changelog.md
+
+### Current Model Assignment Matrix
+
+| Task Type | Model |
+|---|---|
+| File scanning, discovery | haiku |
+| Simple fixes (lint, typos, CSS) | haiku |
+| Standard implementation | sonnet |
+| Bug fix implementation | sonnet |
+| Test writing | sonnet |
+| Sprint orchestration | sonnet |
+| Complex multi-file refactoring | opus |
+| Architectural decisions | opus |
+| Merge conflicts (>3 files) | opus |
+
+## Workflow Changelog (workflow-changelog.md)
+
+Every system change is logged with date, what changed, why, and the source:
+
+```markdown
+## 2026-03-14
+- **Changed:** Added rate limiting check to OAuth callback
+  - **Why:** Code reviewer flagged potential abuse vector
+  - **Source:** Sprint 03-route-protection code review
+```
+
+This provides:
+- **Provenance:** Why was this rule added?
+- **Regression tracking:** Was a change reverted?
+- **Velocity monitoring:** Is the system learning (changes happening) or stagnating?
+
+## Session Postmortems
+
+Structured post-session analysis stored in `evolution/session-postmortems/`:
+
+```markdown
+# Session Postmortem: 2026-03-14 OAuth Implementation
+
+## Metrics
+- Total retries: 4
+- Phases that caught bugs: [Phase 5.3 route health, Phase 5.5 plan audit]
+- Model performance: sonnet 8/10 first-try success
+
+## What Worked
+- File boundaries prevented parallel sprint conflicts
+- Inter-batch learning caught a pattern from Sprint 1
+
+## What Didn't
+- Rate limiting concern was caught late (code review, not planning)
+
+## System Improvements Made
+- Added rate limiting to correctness discovery checklist
+```
+
+## Session Learnings
+
+Session learnings are a file-based memory that survives `/compact` (context compression). They use structured categories:
+
+```markdown
+## Errors
+- [ENV] Missing NEXT_PUBLIC_API_URL → added to .env.example
+- [LOGIC] Off-by-one in pagination → fixed with Math.ceil
+
+## Rules Generated
+- Always check .env.example when adding new env vars (category: CONFIG)
+
+## Model Performance
+- sonnet: 8/10 tasks first-try success
+
+## Metrics
+- Total retries: 4
+- Phases that caught bugs: [Gate 3, Gate 5]
+```
+
+### Promotion Path
+
+```
+session-learnings (ephemeral — this session)
+    │
+    ▼  Pattern in 2+ tasks
+docs/solutions/ (project knowledge)
+    │
+    ▼  Appears in 2+ projects
+~/.claude/evolution/ (cross-project)
+    │
+    ▼  Proven effective
+CLAUDE.md / hooks / skills (system-level)
+```
+
+## The Compound Step
+
+The compound step is what transforms experience into system improvement:
+
+1. **Capture:** What worked? What didn't? Reusable insight?
+2. **Document:** Create solution doc if reusable. Update session learnings.
+3. **Update the system:** If a rule/pattern needs changing, do it now.
+4. **Verify:** "Would the system catch this automatically next time?" If no, compound is incomplete.
+5. **Capture user corrections** as error-registry entries and model-performance data.
+
+The Three Compound Questions:
+1. "What was the hardest decision made here?"
+2. "What alternatives were rejected, and why?"
+3. "What are we least confident about?"
+
+---
+
+Next: [Verification & Quality](11-verification-and-quality.md)

--- a/workflow/11-verification-and-quality.md
+++ b/workflow/11-verification-and-quality.md
@@ -1,0 +1,122 @@
+# Verification & Quality
+
+## The 6 Verification Gates
+
+Every agent must pass these blocking verification gates. A gate is NEVER skipped or silently marked as passed.
+
+### Gate Application by Agent
+
+```
+Sprint-Executor:
+  Gate 1 (Static Analysis) → Gate 5 (Plan Completeness Audit)
+
+Orchestrator:
+  Gate 1 (Coherence) → Gate 2 (Dev Server) → Gate 3 (Content) → Gate 5 (Plan Audit)
+
+Plan-Build-Test Phase 5:
+  Gate 1 → Gate 2 → Gate 3 → Gate 4 (Routes) → Gate 6 (E2E) → Gate 5 (Plan Audit)
+```
+
+### Gate Details
+
+| Gate | What It Catches | What It Does NOT Catch |
+|---|---|---|
+| **1. Static Analysis** (build, lint, types, tests) | Syntax errors, type mismatches, test regressions | Runtime failures, rendering bugs |
+| **2. Dev Server Startup** | Missing deps, config errors, port conflicts | Routes that 200 but show error content |
+| **3. Content Verification** | 200 responses with error pages, empty renders, stale cache | N/A — ultimate check |
+| **4. Route Health** | Missing pages, broken dynamic routes, locale errors | Content correctness (Gate 3 handles that) |
+| **5. Plan Completeness Audit** | Partial completion claimed as full, forgotten tasks | N/A — final check |
+| **6. E2E / Playwright** | Visual bugs, console errors, navigation failures | N/A — full user flow testing |
+
+**Why sprint-executors skip Gates 2 and 3:** Sprint-executors work in isolated worktrees. Running a dev server per worktree would be redundant. The orchestrator runs Gates 2 and 3 after merging all sprints — testing the integrated code.
+
+### Anti-Patterns (things that look like verification but aren't)
+
+| Looks Like Verification | Why It's Not | Do This Instead |
+|---|---|---|
+| "All 128 tests pass" | Tests can pass while app is broken | Start dev server, curl routes, check content |
+| "Build succeeded" | Build does not equal runtime correctness | Verify routes serve correct content |
+| "HTTP 200 on all routes" | 200 can contain error pages | Check response body for expected content |
+| "Dev server starts" | Starting ≠ serving correct content | Curl routes and inspect response bodies |
+
+## Anti-Goodhart Verification
+
+**Goodhart's Law:** "When a measure becomes a target, it ceases to be a good measure."
+
+In AI testing: if you tell the agent "make all tests pass," it can make tests pass without verifying real behavior — weak assertions, removed checks, or tests that validate output without checking if it's correct.
+
+Before marking any task complete, verify:
+
+1. Do tests validate actual **BEHAVIOR** or just **OUTPUT**?
+2. Did I add a test just to "make it pass" without verifying the real scenario?
+3. Does E2E test the **USER flow** or just the **DEVELOPER flow**?
+4. Are there scenarios the tests don't cover that acceptance criteria imply?
+5. Could functional tests pass while security-relevant behaviors are missing?
+
+**Why this matters:** "Vibe testing" — when AI-generated tests technically pass, inflate coverage metrics, and give false confidence — is one of the most dangerous failure modes of AI-assisted development.
+
+## Anti-Premature Completion Protocol
+
+This protocol exists because of repeated incidents where tasks were declared "complete" while the actual running application was broken.
+
+### The Three Completion Lies (never do these)
+
+1. **"All tests pass"** — Tests passing does NOT mean the feature works. Tests can pass while the app shows a visible bug, the dev server cache is corrupted, or runtime dependencies are missing.
+
+2. **"Build complete"** — A build completing does NOT mean the app runs. You MUST start the dev server and verify actual routes return correct content.
+
+3. **"All items done"** — Claiming completion without re-reading the original plan. Before declaring done: re-read the plan, enumerate every item, cite specific evidence for each.
+
+### Mandatory Completion Checklist
+
+Before saying "done":
+
+```
+1. Re-read the original plan/spec       (not from memory — actually read it)
+2. Enumerate remaining items             (list every unchecked - [ ])
+3. Cite evidence for each criterion      ("criterion X verified by [command]
+                                           which returned [output]")
+4. Start the dev server                  (verify key routes serve correct content)
+5. If ANY item is incomplete             (complete it or report it — NEVER claim
+                                           completion with unfinished items)
+```
+
+### When to STOP and Report Instead of Claiming Done
+
+- Dev server won't start → **BLOCKED**, not "complete with known issue"
+- Tests pass but you haven't visually verified → **NOT DONE**
+- You checked off tasks but didn't re-read the plan → **NOT DONE**
+- You can't cite specific evidence for a criterion → **NOT MET**
+
+## Verification Integrity Rules
+
+- NEVER claim a command "passed" without running it and seeing the output
+- NEVER write "lint: PASS (0 issues)" without a preceding lint command execution
+- NEVER mark E2E as "PASS" without a preceding E2E command execution
+- If blocked (environment limitation, missing tool): mark as `BLOCKED`, never as `PASS`
+- Session learnings verification sections must include actual exit codes
+
+## Adaptive Retry Budget
+
+Different failure types get different retry allowances:
+
+| Failure Type | Max Retries | Rationale |
+|---|---|---|
+| `transient` (network, timeout, flaky test) | 5 | Usually resolves itself |
+| `logic` (wrong approach, broken implementation) | 2, then different approach | Repeating bad approach wastes time |
+| `environment` (proot limitation, missing binary) | 1, then mark BLOCKED | Can't fix the environment |
+| `config` (bad setting, wrong flag) | 3 | Usually trial-and-error solvable |
+
+## Scope Boundary Enforcement
+
+If during implementation you discover:
+
+- **Related bug in different area** — log in PRD under "Issues Found", do NOT fix
+- **Opportunity to improve unrelated code** — log it, do NOT do it
+- **Already-broken test** — log it, do NOT fix (unless in sprint scope)
+
+Stay in scope. Resist "one more thing."
+
+---
+
+Next: [proot-distro Guide](12-proot-distro-guide.md)

--- a/workflow/12-proot-distro-guide.md
+++ b/workflow/12-proot-distro-guide.md
@@ -1,0 +1,102 @@
+# proot-distro ARM64 Guide
+
+This section handles a specific but important use case: running the workflow on ARM64 devices using proot-distro (common with Termux on Android tablets).
+
+## Why Special Handling Is Needed
+
+proot-distro is a user-space process emulator. It doesn't have a real kernel — it intercepts system calls and translates them. This causes several classes of failures:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│            PROOT-DISTRO LIMITATIONS                      │
+│                                                          │
+│  ✗ Native binaries may crash (SIGSEGV, SIGBUS)          │
+│  ✗ inotify doesn't work (no file watching)              │
+│  ✗ /proc is limited                                     │
+│  ✗ Chromium cannot run (no GPU, limited syscalls)        │
+│  ✗ Everything runs 2-5x slower                          │
+│                                                          │
+│  ✓ Polling-based file watching works                     │
+│  ✓ JavaScript-only alternatives work                     │
+│  ✓ browser_snapshot (accessibility tree) works            │
+│  ✓ python3 http.server works                             │
+│  ✓ Node.js with increased memory works                   │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Auto-Detection
+
+If `uname -r` contains `PRoot-Distro` AND `uname -m` = `aarch64`, all proot rules activate automatically. Three layers handle proot:
+
+1. **settings.json env:** Sets `NODE_OPTIONS`, `CHOKIDAR_USEPOLLING`, `WATCHPACK_POLLING` globally
+2. **proot-preflight.sh:** Runs once per session; warns about disk, symlinks, SST locks
+3. **worktree-preflight.sh:** Called by orchestrator; sets env vars and fixes deps for sprint execution
+
+## Mandatory Rules
+
+| Rule | Why |
+|---|---|
+| NEVER `playwright install chromium` | Chromium doesn't run in proot. Use `browser_snapshot` instead. |
+| NEVER trust `pnpm install` blindly | Check `.npmrc` for `node-linker=hoisted`. Verify symlinks after install. |
+| NEVER set tight timeouts | Everything runs 2-5x slower. Multiply by 3x minimum. |
+| NEVER use Lighthouse as quality gate | Scores unreliable in proot. Mark as `BLOCKED: proot-distro ARM64`. |
+| ALWAYS use polling for file watching | `CHOKIDAR_USEPOLLING=true` set globally in settings.json |
+| ALWAYS use retry-with-backoff for APIs | Source `~/.claude/hooks/retry-with-backoff.sh` |
+
+## Known Native Module Failures
+
+These packages have native binaries that WILL fail in proot-distro:
+
+| Package | Issue | Workaround |
+|---|---|---|
+| `@parcel/watcher` | Native binary crash | `PARCEL_WATCHER_BACKEND=fs-events` or JS fallback |
+| `@rollup/rollup-linux-arm64-gnu` | Binary incompatible | `--ignore-scripts` and rebuild selectively |
+| `sharp` | Native image processing | JS-based image processing alternatives |
+| `turbo` (native) | Binary crash | Non-native mode |
+| Any `node-gyp` build | Compilation fails | Prefer JS alternatives |
+
+## Common Error Patterns
+
+| Error | Root Cause | Fix |
+|---|---|---|
+| `ENOENT .bin/` | Broken symlink in node_modules | `pnpm install` with correct `.npmrc` |
+| `spawn EACCES` | Binary not executable | Use JS alternative |
+| `heap out of memory` | Default Node.js limit too low | `NODE_OPTIONS=--max-old-space-size=2048` (set globally) |
+| `Chromium not found` | Can't run Chromium in proot | Use `browser_snapshot` MCP tool |
+| `SIGBUS/SIGSEGV` on native binary | proot syscall translation failure | Use JS fallback |
+| `inotify_add_watch` | inotify not available | Polling already enabled globally |
+
+## Go Binary /.l2s/ Fix
+
+Go binaries resolve libraries via `/proc/self/exe`, which proot translates to `/.l2s/`. Copy required resource files there:
+
+```bash
+if [ -d "/.l2s" ]; then cp /path/to/lib/*.d.ts /.l2s/; fi
+```
+
+Already handled for tsgo in `end-of-turn-typecheck.sh`.
+
+## Playwright in proot
+
+Chromium-based browser automation doesn't work in proot. Instead:
+
+- Use `browser_snapshot` (accessibility tree) — works perfectly
+- Never use `browser_take_screenshot` — requires Chromium
+- E2E tests should use accessibility-tree-based assertions
+
+## Performance Expectations
+
+Everything runs 2-5x slower in proot-distro. Plan accordingly:
+
+| Operation | Normal | proot-distro |
+|---|---|---|
+| `pnpm install` | 30s | 1-2min |
+| `pnpm build` | 1min | 2-5min |
+| Type checking | 10s | 30s-1min |
+| Test suite | 30s | 1-2min |
+
+Multiply all timeouts by 3x minimum.
+
+---
+
+Next: [End-to-End Example](13-end-to-end-example.md)

--- a/workflow/13-end-to-end-example.md
+++ b/workflow/13-end-to-end-example.md
@@ -1,0 +1,149 @@
+# End-to-End Example
+
+This walkthrough shows the complete system in action for a real scenario: adding Google OAuth authentication to a Next.js app.
+
+## The Request
+
+```
+YOU: "I need to implement login with Google OAuth in my Next.js app"
+```
+
+## Phase 1: Planning (/plan auto-invokes)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ 1. Classifies as PRD+Sprint (multi-component, >1h work)                │
+│                                                                         │
+│ 2. Contract-First:                                                      │
+│    "I understand you want: login via Google OAuth using NextAuth.js,    │
+│     redirecting to /dashboard after login. Correct?"                    │
+│                                                                         │
+│ 3. Correctness Discovery (all 6 questions):                             │
+│    Audience: End users                                                  │
+│    Failure: Login that doesn't persist                                  │
+│    Danger: Token leak                                                   │
+│    Uncertainty: STOP (it's security)                                    │
+│    Risk: Unauthorized access > refused login                            │
+│    Verification: E2E test of complete login flow                        │
+│                                                                         │
+│ 4. PRD created at docs/tasks/auth/feature/2026-03-14_1400-oauth/       │
+│    ├── spec.md (the PRD)                                                │
+│    ├── progress.json                                                    │
+│    └── sprints/                                                         │
+│        ├── 01-setup-nextauth.md (Sprint 1)                              │
+│        ├── 02-login-ui.md (Sprint 2 — parallel with 3)                  │
+│        └── 03-route-protection.md (Sprint 3 — parallel with 2)          │
+│                                                                         │
+│ 5. Spec Self-Evaluator: 12/14, approved                                 │
+│                                                                         │
+│ 6. "PRD saved. Run /plan-build-test to execute."                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The user reviews the PRD, confirms it's correct, and proceeds.
+
+## Phase 2: Execution (/plan-build-test — autonomous)
+
+```
+YOU: "/plan-build-test"
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Phase 0: Finds progress.json with 3 pending sprints                     │
+│                                                                         │
+│ Phase 3: Execution begins                                               │
+│                                                                         │
+│   Batch 1: Sprint 1 (sequential — dependency for 2 and 3)              │
+│   ┌─────────────────────────────────────────────────────────┐           │
+│   │ Orchestrator spawns sprint-executor in worktree          │           │
+│   │ → Executor implements NextAuth setup with TDD            │           │
+│   │ → Marks checkboxes, fills Agent Notes                    │           │
+│   │ → Returns: PASS (build, lint, types, tests)              │           │
+│   │ → Orchestrator verifies coherence, runs dev server       │           │
+│   │ → Content verified: NextAuth API routes responding       │           │
+│   └─────────────────────────────────────────────────────────┘           │
+│                                                                         │
+│   Batch 2: Sprints 2 + 3 (parallel — different files)                  │
+│   ┌──────────────────────┐  ┌──────────────────────────┐               │
+│   │ Sprint 2 (worktree)  │  │ Sprint 3 (worktree)      │               │
+│   │ Login UI components  │  │ Route protection          │               │
+│   │ (own branch)         │  │ middleware (own branch)   │               │
+│   └──────────┬───────────┘  └────────────┬─────────────┘               │
+│              │                            │                             │
+│              ▼                            ▼                             │
+│   Orchestrator merges both (sequential, lowest sprint first)            │
+│   → No conflicts (different files)                                      │
+│   → Code reviewer: PASS, 1 finding: "consider rate limiting callback"  │
+│   → Dev server: content verified on all auth routes                     │
+│                                                                         │
+│ Phase 5: Live Verification                                              │
+│   Build: PASS | Lint: PASS | Types: PASS | Tests: 15/15 PASS           │
+│   Dev server: PASS (port 3000)                                          │
+│   Content: /login shows login form, /dashboard requires auth            │
+│   Route health: 12/12 routes returning 200                              │
+│   Plan completeness: 3/3 sprints complete, all criteria met             │
+│                                                                         │
+│ Phase 6: Learning captured, error-registry updated                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The user manually tests the feature — everything works.
+
+## Phase 3: Shipping (/ship-test-ensure — autonomous through staging)
+
+```
+YOU: "/ship-test-ensure"
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Phase 1: Create branch ship/20260314-1430-google-oauth                  │
+│          Commit, push, create PR, wait for CI, merge                    │
+│                                                                         │
+│ Phase 2: Monitor staging deploy on GitHub Actions                       │
+│          All workflows green                                            │
+│                                                                         │
+│ Phase 3: E2E on staging: 8/8 tests pass                                 │
+│                                                                         │
+│ Phase 4: ★ "Staging verified. Deploy to production?" ★                  │
+│          YOU: "Deploy all"                                               │
+│          Production deploy triggered, monitored, green                  │
+│                                                                         │
+│ Phase 5: Lighthouse on production                                       │
+│          Performance: 100 | A11y: 100 | Best Practices: 100 | SEO: 100│
+│                                                                         │
+│ Phase 6: Final report + compound                                        │
+│          Hardest decision: Rate limiting on OAuth callback               │
+│          Rejected: Manual OAuth (NextAuth more secure)                   │
+│          Least confident: Rate limit threshold                           │
+│          → NextAuth pattern promoted to docs/solutions/auth/             │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## What Happened Behind the Scenes
+
+1. **Contract-First** prevented misunderstanding the requirement
+2. **Correctness Discovery** identified security as the uncertainty policy (STOP, don't guess)
+3. **File boundaries** in sprint specs enabled Sprint 2 and Sprint 3 to run in parallel
+4. **Worktree isolation** gave each sprint its own branch and directory
+5. **Anti-Goodhart verification** ensured tests validated real OAuth behavior
+6. **Content verification** (not just HTTP 200) confirmed the login form rendered
+7. **Code review** caught a rate limiting concern that planning missed
+8. **Inter-batch learning** would have passed Sprint 1 insights to Sprint 2/3 if there were errors
+9. **Mandatory user confirmation** before production deploy
+10. **Compound step** captured learnings and promoted the NextAuth pattern
+
+## User Touchpoints
+
+The user only needed to:
+
+1. Describe the feature (1 message)
+2. Confirm the Contract-First mirror (1 message)
+3. Review the PRD (1 read)
+4. Say "/plan-build-test" (1 message)
+5. Test manually (hands-on)
+6. Say "/ship-test-ensure" (1 message)
+7. Confirm production deploy (1 message)
+
+Everything else was autonomous — planning, sprint decomposition, parallel execution, merging, verification, CI/CD, staging E2E, and learning capture.
+
+---
+
+Next: [Design Principles](14-design-principles.md)

--- a/workflow/14-design-principles.md
+++ b/workflow/14-design-principles.md
@@ -1,0 +1,80 @@
+# Design Principles
+
+Ten recurring principles guide the entire system. Understanding them helps you extend the system correctly and diagnose problems when they occur.
+
+## 1. Match Ceremony to Complexity
+
+The amount of process should be proportional to the risk. Quick Fix for trivialities, Standard for moderate work, PRD+Sprint for complex features.
+
+Using a full PRD for a CSS fix is bureaucracy. Using Quick Fix for a payment system is reckless.
+
+## 2. Deterministic Enforcement Over Hopeful Suggestions
+
+Hooks > instructions. Code that prevents > text that asks.
+
+CLAUDE.md says "use pnpm not npm." The model might forget. But `block-dangerous.sh` physically blocks npm commands — the model cannot bypass it. For rules that must never be broken, use hooks. For guidelines, use CLAUDE.md.
+
+## 3. Separate Concerns, Minimize Privilege
+
+Each agent has only what it needs:
+- **Reviewer** doesn't edit (reports, doesn't fix)
+- **Executor** doesn't delegate (implements, doesn't manage)
+- **Orchestrator** doesn't implement (manages, doesn't code)
+
+This prevents role confusion and limits blast radius when something goes wrong.
+
+## 4. Fresh Context Is Better Than Stale Context
+
+Starting clean > dragging a long conversation. Save state to files, not to conversation history.
+
+This is why:
+- One orchestrator invocation = one batch
+- Sprint agents get only their sprint spec
+- Session learnings are file-based (survive context compression)
+- Each major skill works best in a fresh context window
+
+## 5. Knowledge Compounds — Capture It
+
+Every task must improve the system. If an error happens twice, it must become a rule that prevents the third time.
+
+The compound step is not optional — it's blocking. Without it, you have "engineering with AI assistance." With it, you have a system that gets better with every use.
+
+## 6. Plan + Review = 80%, Work + Compound = 20%
+
+The bottleneck is not implementation — it's knowing what to implement and verifying the result.
+
+With AI agents, typing speed is irrelevant. What matters is:
+- Understanding the requirement correctly (Plan)
+- Verifying the output is correct (Review)
+- Implementation and learning capture are the smaller portion
+
+## 7. Scope Discipline
+
+Stay in scope. Log adjacent problems instead of solving them. "Just one more thing" is the enemy of delivery.
+
+If you find a bug in another area, log it. If you see code that could be improved, log it. Don't fix it now. Scope creep is how sprints go from 30 minutes to 3 hours.
+
+## 8. Binary Verifiability
+
+If you can't write a pass/fail test for a criterion, it's not a valid criterion.
+
+"Make it fast" is not verifiable. "LCP < 2s" is. "Make it user-friendly" is not verifiable. "Core task in < 3 clicks" is.
+
+## 9. Evidence Over Claims
+
+"Tests pass" is not evidence. "Route /login returns 200 and response body contains login form with Google button" is evidence.
+
+This principle drives:
+- Content verification (not just HTTP 200)
+- Mandatory completion checklist (cite specific evidence)
+- Verification Integrity rules (never claim PASS without running the command)
+
+## 10. The System Improves Itself
+
+This is the meta-principle. The error-registry grows. Model assignments adapt. Hooks get added. Skills get refined. Each session leaves the system better than it found it.
+
+Without this, you have a static set of tools. With this, you have a living system that evolves to match your needs.
+
+---
+
+Next: [Glossary](15-glossary.md)

--- a/workflow/15-glossary.md
+++ b/workflow/15-glossary.md
@@ -1,0 +1,47 @@
+# Glossary
+
+| Term | Definition |
+|---|---|
+| **ADR** | Architecture Decision Record — document capturing a significant architectural decision with context, options, and consequences |
+| **Anti-Goodhart** | Verification that tests measure real behavior, not just metrics. Named after Goodhart's Law: "When a measure becomes a target, it ceases to be a good measure" |
+| **Batch** | A group of sprints that can run in parallel because they have no file overlaps or dependencies |
+| **Biome** | Fast Rust-based formatter and linter for JS/TS/JSON/CSS, alternative to Prettier + ESLint |
+| **CLS** | Cumulative Layout Shift — how much a page "jumps" during loading. Target: < 0.1 |
+| **Compound** | The phase where learnings from a task are captured and the system improves itself |
+| **Compound Engineering** | Engineering approach where each task not only delivers the result but improves the system for future tasks |
+| **Contract-First** | Pattern: user describes intent → agent mirrors understanding → user confirms before execution begins |
+| **Context Rot** | Quality degradation when the context window fills up, causing the model to "forget" earlier instructions |
+| **Context Window** | Maximum tokens the model can process at once — the model's "working memory" |
+| **Correctness Discovery** | 6-question framework for defining what "correct" means before building anything |
+| **E2E** | End-to-End testing — tests that simulate complete user flows through the application |
+| **Error Registry** | Cross-project database (`error-registry.json`) of error patterns, root causes, fixes, and failed approaches |
+| **Evolution** | The system's self-improvement mechanism — tracking errors, model performance, and system changes across all projects |
+| **Execution Config** | Project-specific commands and URLs defined in a project's `CLAUDE.md` that skills read to know how to build, test, deploy, etc. |
+| **File Boundaries** | Declaration in sprint specs of which files a sprint creates, modifies, reads, and shares — prevents parallel sprint conflicts |
+| **Frontmatter** | YAML block at the start of a markdown file defining metadata (name, model, tools, etc.) |
+| **Haiku** | Claude's lightest/fastest model — used for scanning, discovery, and simple tasks |
+| **Hook** | Script that runs automatically at lifecycle points in Claude Code (PreToolUse, PostToolUse, Stop, Notification) |
+| **INP** | Interaction to Next Paint — response time to user interactions. Target: < 200ms |
+| **LCP** | Largest Contentful Paint — time until the largest visible element renders. Target: < 2.5s |
+| **LSP** | Language Server Protocol — understands code semantics for precise navigation (goToDefinition, findReferences, etc.) |
+| **Micro-Compound** | Abbreviated compound for Quick Fix mode: one question — "Would the system catch this next time?" |
+| **Mode Fluency** | The practice of switching freely between Quick Fix, Standard, and PRD+Sprint modes within a single task |
+| **Opus** | Claude's most powerful/expensive model — used for complex refactoring, architecture decisions, and merge conflicts |
+| **Orchestrator** | Agent that manages sprint lifecycle, delegates to executors, and handles merging — never implements code directly |
+| **pnpm** | Fast, efficient Node.js package manager that shares dependencies via hard links instead of copying |
+| **PRD** | Product Requirements Document — specification that defines what to build and why |
+| **proot-distro** | User-space process emulator for running Linux on ARM64 devices (e.g., Termux on Android) |
+| **Quick Fix** | Execution mode for trivial fixes — single file, < 30 lines, no architectural impact |
+| **Session Learnings** | File-based session memory that survives context compression (`/compact`) |
+| **Skill** | Auto-invocable workflow defined in `skills/` with a `SKILL.md` file |
+| **Sonnet** | Claude's balanced model — used for standard implementation, testing, bug fixes, and orchestration |
+| **Sprint** | Self-contained unit of work within a PRD, designed for one agent in a healthy context window |
+| **Sprint Executor** | Agent that receives a sprint spec and implements it within an isolated worktree |
+| **TDD** | Test-Driven Development — write tests before production code (Red → Green → Refactor) |
+| **Verification Gate** | One of 6 blocking quality checks that must pass before work can be marked complete |
+| **Worktree** | Isolated Git working copy with its own branch — used for parallel sprint execution without file conflicts |
+| **XSS** | Cross-Site Scripting — web security vulnerability where malicious scripts are injected into web pages |
+
+---
+
+Back to [Documentation Index](README.md)

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,32 @@
+# Workflow Documentation Index
+
+Detailed documentation for the Claude Workflow System. See the [main README](../README.md) for a quick overview and setup instructions.
+
+## Sections
+
+### Getting Started
+1. [Introduction](01-introduction.md) — What, why, and the Compound Engineering philosophy
+2. [Getting Started](02-getting-started.md) — Installation, setup, first run, project configuration
+
+### Understanding the System
+3. [Architecture](03-architecture.md) — Repository structure, layers, how everything connects
+4. [The Constitution](04-constitution.md) — Value hierarchy, decision boundaries, autonomous authority
+5. [Workflow & Modes](05-workflow-and-modes.md) — Execution modes, Contract-First, autonomous pipeline
+6. [Sprint System](06-sprint-system.md) — PRDs, sprint decomposition, templates, file boundaries
+
+### Components
+7. [Agents](07-agents.md) — Orchestrator, Sprint Executor, Code Reviewer
+8. [Skills Reference](08-skills-reference.md) — /plan, /plan-build-test, /ship-test-ensure, /compound, /workflow-audit
+9. [Hooks & Enforcement](09-hooks-and-enforcement.md) — settings.json, hook lifecycle, adding custom hooks
+10. [Evolution & Learning](10-evolution-and-learning.md) — Cross-project learning, error registry, model performance
+
+### Quality & Verification
+11. [Verification & Quality](11-verification-and-quality.md) — 6 verification gates, Anti-Goodhart, Anti-Premature Completion
+
+### Specialized Topics
+12. [proot-distro Guide](12-proot-distro-guide.md) — ARM64 environment, known issues, workarounds
+13. [End-to-End Example](13-end-to-end-example.md) — Complete walkthrough: feature request to production
+
+### Reference
+14. [Design Principles](14-design-principles.md) — 10 recurring principles
+15. [Glossary](15-glossary.md) — Terms and definitions


### PR DESCRIPTION
## Summary
- Added 15 focused documentation files under `workflow/` covering the entire system: introduction, setup, architecture, constitution, modes, sprints, agents, skills, hooks, evolution, verification, proot-distro, end-to-end example, design principles, and glossary
- Merged and upgraded `README.md` as the main entry point with quick start, structure overview, skill/agent/hook summaries, and links to all deep-dive sections
- Total: 2,530 lines of documentation split into navigable sections

## Test plan
- [ ] Verify all internal links between workflow/ files resolve correctly
- [ ] Verify README.md links to workflow/ sections work
- [ ] Review content accuracy against CLAUDE.md, agents/, skills/, and hooks/

🤖 Generated with [Claude Code](https://claude.com/claude-code)