### PR TITLE
docs: add caution notice about user-level config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ This system is primarily shaped by hands-on experience building production softw
 
 ## Quick Start
 
+> **CAUTION:** This system installs to `~/.claude/`, which is the **user-level** configuration directory for Claude Code. Cloning this repository will **replace your existing personal configuration** — including your `CLAUDE.md`, `settings.json`, hooks, and any other customizations you've made. This is NOT a per-project setup; it affects **every project** you open with Claude Code. Back up your existing `~/.claude/` directory before proceeding.
+
 ```bash
-# 1. Clone to ~/.claude/
+# 1. Back up your existing configuration (important!)
+cp -r ~/.claude ~/.claude.backup 2>/dev/null
+
+# 2. Clone to ~/.claude/
 git clone <repository-url> ~/.claude
 
-# 2. Open any project with Claude Code
+# 3. Open any project with Claude Code
 cd /path/to/your/project
 claude
 
-# 3. That's it — the system loads automatically
+# 4. That's it — the system loads automatically
 ```
 
 Hooks enforce rules deterministically, agents handle complex work, and skills auto-invoke based on what you're doing. Project-specific context goes in each project's own `CLAUDE.md` (see [Getting Started](workflow/02-getting-started.md)).

--- a/workflow/02-getting-started.md
+++ b/workflow/02-getting-started.md
@@ -9,11 +9,21 @@
 
 ## Installation
 
-### Step 1: Clone the Repository
+> **CAUTION — User-Level Configuration Override**
+>
+> This system installs to `~/.claude/`, which is the **user-level** configuration directory for Claude Code. This means:
+>
+> - It **replaces your entire personal configuration** — `CLAUDE.md`, `settings.json`, hooks, and all other files in `~/.claude/`
+> - It is **NOT per-project** — it applies globally to **every project** you open with Claude Code
+> - Any existing personal customizations (custom hooks, settings, memory files, evolution data) **will be overwritten**
+>
+> **Always back up your existing `~/.claude/` directory before installing.** If you have custom configurations you want to preserve, review the backup after installation and merge them manually into the new system.
+
+### Step 1: Back Up and Clone the Repository
 
 ```bash
-# If ~/.claude/ already exists, back it up first
-mv ~/.claude ~/.claude.backup 2>/dev/null
+# Back up your existing configuration (do NOT skip this)
+cp -r ~/.claude ~/.claude.backup 2>/dev/null
 
 # Clone the workflow system
 git clone <repository-url> ~/.claude


### PR DESCRIPTION
## Summary
- Added prominent caution notice to **README.md** Quick Start section warning that installation replaces the user's entire `~/.claude/` personal configuration
- Added detailed caution callout to **workflow/02-getting-started.md** explaining what gets overwritten and recommending backup before install
- Changed the install step from `mv` to `cp -r` for backup (preserves original in place) and renamed it to "Back Up and Clone"

## Test plan
- [ ] Verify caution block renders correctly in GitHub markdown (both files)
- [ ] Confirm backup command in Quick Start uses `cp -r` (non-destructive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)