### PR TITLE
docs: update docs for new hooks + add push gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ The core loop. Plan + Review = 80% of effort. Work + Compound = 20%. The bottlen
 │   ├── post-edit-quality.sh   # Auto-formats TS/JS after every edit
 │   ├── end-of-turn-typecheck.sh # Type-checks before session end
 │   ├── compound-reminder.sh   # Blocks session end without learning capture
-│   └── verify-completion.sh   # Blocks premature completion claims
+│   ├── verify-completion.sh   # Blocks premature completion claims
+│   ├── validate-i18n-keys.sh  # Cross-validates i18n keys across locales
+│   ├── verify-worktree-merge.sh # Detects silent overwrites in worktree merges
+│   └── check-docs-updated.sh # Blocks push if workflow changed without doc updates
 ├── test-workflow-mods/# Workflow integrity test suite (123 assertions)
 │   ├── run-tests.sh           # Validates entire ~/.claude/ structure
 │   └── testdata/              # Fixture projects for hook behavioral tests
@@ -86,7 +89,7 @@ The core loop. Plan + Review = 80% of effort. Work + Compound = 20%. The bottlen
 |---|---|---|
 | `/plan` | Generates PRD only | "Just plan, don't build yet" |
 | `/plan-build-test` | Plans, executes with agent teams, verifies locally | "Build this feature / fix this bug" |
-| `/ship-test-ensure` | Branch, PR, staging E2E, production deploy, Lighthouse | "Ship what I've built" |
+| `/ship-test-ensure` | Branch, PR, staging E2E, production deploy, Lighthouse (optional) | "Ship what I've built" |
 | `/compound` | Captures learnings, updates error registry, evolves system | Auto-invoked after task completion |
 | `/workflow-audit` | Reviews model performance, error patterns, rule staleness | Monthly or after 10+ sessions |
 
@@ -113,6 +116,9 @@ The system uses deterministic hooks — real code that runs before/after every a
 | `end-of-turn-typecheck.sh` | Session end | Type-checks TypeScript |
 | `compound-reminder.sh` | Session end | Blocks exit without learning capture |
 | `verify-completion.sh` | Session end | Blocks premature completion without evidence |
+| `validate-i18n-keys.sh` | Pre-commit (via ship-test-ensure) | Cross-validates all i18n t() keys exist in all locale files |
+| `verify-worktree-merge.sh` | Post-merge (via orchestrator) | Detects files silently overwritten by worktree merges |
+| `check-docs-updated.sh` | Every `git push` (PreToolUse) | Blocks push if hooks/skills/agents changed without doc updates |
 
 ### Workflow Integrity Tests
 

--- a/hooks/check-docs-updated.sh
+++ b/hooks/check-docs-updated.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# check-docs-updated.sh — Validates that docs are updated when workflow files change.
+# Designed to run as a PreToolUse(Bash) hook, triggered on git push commands.
+# Also callable standalone: check-docs-updated.sh [base-branch]
+#
+# Exit codes: 0 = pass (docs updated or no workflow changes), 2 = block (docs stale)
+
+set -euo pipefail
+
+# When called as a hook, $1 is the tool input JSON. Detect if this is a push command.
+if [ -n "${1:-}" ]; then
+  # Check if this is a git push command
+  COMMAND="$1"
+  if ! echo "$COMMAND" | grep -qE 'git\s+push'; then
+    exit 0  # Not a push — skip
+  fi
+fi
+
+# Must be in the ~/.claude repo
+REPO_ROOT="$(git -C ~/.claude rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ] || [ "$REPO_ROOT" != "$(cd ~/.claude && pwd)" ]; then
+  exit 0  # Not in the workflow repo
+fi
+
+cd "$REPO_ROOT"
+
+BASE_BRANCH="${1:-main}"
+# If called as hook, base branch is always main
+if echo "${1:-}" | grep -q 'git'; then
+  BASE_BRANCH="main"
+fi
+
+# Get files changed compared to base branch (or HEAD~1 if on main)
+if [ "$(git branch --show-current)" = "$BASE_BRANCH" ]; then
+  CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || true)
+else
+  CHANGED_FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || true)
+fi
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0  # No changes
+fi
+
+# Define workflow files that require doc updates
+WORKFLOW_CHANGED=false
+DOC_CATEGORIES=""
+
+# Check hooks
+if echo "$CHANGED_FILES" | grep -qE '^hooks/.*\.sh$'; then
+  WORKFLOW_CHANGED=true
+  DOC_CATEGORIES="$DOC_CATEGORIES hooks"
+fi
+
+# Check skills
+if echo "$CHANGED_FILES" | grep -qE '^skills/.*SKILL\.md$'; then
+  WORKFLOW_CHANGED=true
+  DOC_CATEGORIES="$DOC_CATEGORIES skills"
+fi
+
+# Check agents
+if echo "$CHANGED_FILES" | grep -qE '^agents/.*\.md$'; then
+  WORKFLOW_CHANGED=true
+  DOC_CATEGORIES="$DOC_CATEGORIES agents"
+fi
+
+# Check settings.json
+if echo "$CHANGED_FILES" | grep -qE '^settings\.json$'; then
+  WORKFLOW_CHANGED=true
+  DOC_CATEGORIES="$DOC_CATEGORIES settings"
+fi
+
+if [ "$WORKFLOW_CHANGED" = "false" ]; then
+  exit 0  # No workflow files changed
+fi
+
+# Check if docs were also updated
+DOCS_UPDATED=false
+
+if echo "$CHANGED_FILES" | grep -qE '^README\.md$'; then
+  DOCS_UPDATED=true
+fi
+
+if echo "$CHANGED_FILES" | grep -qE '^workflow/'; then
+  DOCS_UPDATED=true
+fi
+
+if [ "$DOCS_UPDATED" = "false" ]; then
+  echo "BLOCKED: Workflow files changed (${DOC_CATEGORIES## }) but no documentation updated." >&2
+  echo "" >&2
+  echo "Changed workflow files:" >&2
+  echo "$CHANGED_FILES" | grep -E '^(hooks/|skills/|agents/|settings\.json)' | sed 's/^/  - /' >&2
+  echo "" >&2
+  echo "Please update the relevant docs before pushing:" >&2
+  echo "  - README.md (repository structure, hooks table, skills table)" >&2
+  echo "  - workflow/03-architecture.md (repository structure)" >&2
+  echo "  - workflow/08-skills-reference.md (if skills changed)" >&2
+  echo "  - workflow/09-hooks-and-enforcement.md (if hooks changed)" >&2
+  echo "  - workflow/07-agents.md (if agents changed)" >&2
+  exit 2
+fi
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -54,6 +54,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/proot-preflight.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/check-docs-updated.sh"
           }
         ]
       },

--- a/workflow/03-architecture.md
+++ b/workflow/03-architecture.md
@@ -38,6 +38,9 @@
 │   ├── end-of-turn-typecheck.sh        # Type-checks TypeScript at end of turn
 │   ├── compound-reminder.sh            # Blocks session end without learning capture
 │   ├── verify-completion.sh            # Blocks premature completion claims
+│   ├── validate-i18n-keys.sh           # Cross-validates i18n keys across locales
+│   ├── verify-worktree-merge.sh        # Detects silent overwrites in worktree merges
+│   ├── check-docs-updated.sh           # Blocks push if workflow changed without docs
 │   ├── proot-preflight.sh              # Environment checks for proot-distro
 │   ├── worktree-preflight.sh           # Git and dependency readiness
 │   └── retry-with-backoff.sh           # Utility for API rate limit handling

--- a/workflow/08-skills-reference.md
+++ b/workflow/08-skills-reference.md
@@ -162,11 +162,13 @@ Phase 4: Production Deploy
          ├── Trigger production deploy commands
          └── Monitor with same pattern as Phase 2
 
-Phase 5: PageSpeed & Lighthouse
+Phase 5: PageSpeed & Lighthouse (Optional — requires pages_to_audit config)
+         ├── Skip entirely if no pages_to_audit configured
          ├── Test all configured pages (mobile + desktop)
          ├── Classify: code-fixable / infrastructure / third-party
          ├── Spawn fix agents
-         └── Max 5 iterations; plateau → accept current scores
+         ├── PSI API key supported (PSI_API_KEY env var)
+         └── Max 5 iterations; plateau or 429 quota → accept current scores
 
 Phase 6: Final Report & Compound
          ├── Final Lighthouse score table

--- a/workflow/09-hooks-and-enforcement.md
+++ b/workflow/09-hooks-and-enforcement.md
@@ -35,6 +35,7 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 │  │  PreToolUse      │ ◄── Runs BEFORE every Bash command            │
 │  │  (Bash)          │     block-dangerous.sh: hard/soft blocks      │
 │  │                  │     proot-preflight.sh: environment warnings   │
+│  │                  │     check-docs-updated.sh: doc sync on push   │
 │  └──────────────────┘                                               │
 │                                                                     │
 │  ┌──────────────────┐                                               │
@@ -83,6 +84,9 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 | `end-of-turn-typecheck.sh` | Stop | End of turn | Type-check TypeScript | Yes (exit 2 on type errors) |
 | `compound-reminder.sh` | Stop | End of turn | Ensure /compound ran | Yes (exit 2 if skipped) |
 | `verify-completion.sh` | Stop | End of turn | Block premature completion | Yes (exit 2 without evidence) |
+| `validate-i18n-keys.sh` | (ship-test-ensure) | Pre-commit | Cross-validate i18n keys across locales | No (informational) |
+| `verify-worktree-merge.sh` | (orchestrator) | Post-merge | Detect silent overwrites from worktree merges | No (informational) |
+| `check-docs-updated.sh` | PreToolUse(Bash) | `git push` | Block push if workflow files changed without doc updates | Yes (exit 2 if stale) |
 | `worktree-preflight.sh` | (orchestrator) | Sprint start | Git/env readiness | N/A (utility) |
 | `retry-with-backoff.sh` | (utility) | API calls | Exponential backoff | N/A (utility) |
 
@@ -352,6 +356,91 @@ Evidence marker file exists?
 ```
 
 **Why this matters:** This is the enforcement mechanism for the Anti-Premature Completion Protocol. Without it, the protocol is just instructions the model can ignore.
+
+## PreToolUse: check-docs-updated.sh
+
+Runs **before** every Bash command, but only activates on `git push`. Checks if workflow files (hooks, skills, agents, settings.json) were changed without corresponding documentation updates.
+
+```
+git push command detected
+    │
+    ▼
+In ~/.claude repo? ─── No ──► skip
+    │
+   Yes
+    │
+    ▼
+Workflow files changed vs main?
+(hooks/*.sh, skills/*/SKILL.md, agents/*.md, settings.json)
+    │
+    ├─ No ──► exit 0
+    │
+    └─ Yes
+        │
+        ▼
+    Docs also changed? (README.md or workflow/*)
+        │
+        ├─ Yes ──► exit 0
+        └─ No ──► BLOCK (exit 2)
+             "Workflow files changed but no documentation updated.
+              Update README.md and relevant workflow/ docs."
+```
+
+**Why this matters:** Workflow changes that aren't reflected in docs create drift between what the system does and what the docs say. This hook enforces documentation-as-code for the workflow repo itself.
+
+## Utility: validate-i18n-keys.sh
+
+Called by `/ship-test-ensure` Phase 0.3 before committing. Auto-detects whether the project uses i18n (next-intl, react-intl, i18next) and exits 0 silently if not. For i18n projects, it cross-validates that all `t()` keys referenced in source code exist in all locale JSON files.
+
+```
+Project being committed
+    │
+    ▼
+Has i18n dependency? ─── No ──► exit 0 (skip)
+    │
+   Yes
+    │
+    ▼
+Find all locale JSON files
+    │
+    ▼
+Extract all t() keys from source
+    │
+    ▼
+Cross-validate keys exist in ALL locales
+    │
+    ├─ All present ──► exit 0
+    └─ Missing keys ──► exit 1, report missing keys per locale
+```
+
+**Why this matters:** Build, lint, and type-check do NOT catch missing i18n keys — they only appear as runtime console errors. This hook catches them before they ship.
+
+## Utility: verify-worktree-merge.sh
+
+Called by the orchestrator (Step 6.2) before each worktree branch merge. Detects files that were modified by both the current worktree branch and previously merged sprint branches, which would be silently overwritten.
+
+```
+Worktree branch about to merge
+    │
+    ▼
+Previous sprint SHAs provided? ─── No ──► exit 0 (skip)
+    │
+   Yes
+    │
+    ▼
+Get files modified by worktree branch
+    │
+    ▼
+Get files modified by each previous sprint
+    │
+    ▼
+Find overlap (files touched by both)
+    │
+    ├─ No overlap ──► exit 0
+    └─ Overlap found ──► exit 1, report files for manual verification
+```
+
+**Why this matters:** Worktrees branch from HEAD at creation time. Later sprint merges aren't visible to worktrees created earlier. Without this check, merging a worktree silently reverts changes from already-merged sprints in shared files.
 
 ## Workflow Integrity Tests
 


### PR DESCRIPTION
## Summary
- Updated README.md, architecture, hooks, and skills docs to reflect 3 new hooks added in PR #9: `validate-i18n-keys.sh`, `verify-worktree-merge.sh`, and the new `check-docs-updated.sh`
- **New hook:** `check-docs-updated.sh` — a PreToolUse(Bash) hook that blocks `git push` when workflow files (hooks, skills, agents, settings.json) changed without corresponding documentation updates in README.md or `workflow/`
- Updated ship-test-ensure Phase 5 description as optional (requires `pages_to_audit` config)

## Test plan
- [x] `check-docs-updated.sh` exits 0 outside the workflow repo
- [x] `check-docs-updated.sh` exits 0 on non-push commands
- [x] Hook registered in settings.json PreToolUse(Bash)
- [x] All docs consistently list the same hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)