### PR TITLE
feat: universal language support for all hooks (16 languages)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,10 +345,10 @@ Stay in scope. Resist "one more thing."
 
 The "Agent NEVER does" column is enforced as PreToolUse hooks in `~/.claude/settings.json`, not just prompt suggestions. What hooks actually enforce:
 
-- **PreToolUse(Bash):** Blocks destructive commands and detects proot environment
-- **PreToolUse(Write|Edit):** TDD enforcement — blocks production code edits if no corresponding test file exists (`check-test-exists.sh`). Write the test first.
-- **PostToolUse(Write|Edit):** Auto-formats TS/JS files if Biome or ESLint is configured (skips silently if no linter found; exit 2 on unfixable lint errors). Then verifies INVARIANTS.md rules — blocks if any machine-verifiable invariant is violated (`check-invariants.sh`).
-- **Stop:** Type-checks TypeScript (exit 2 on type errors), reminds to run /compound when PRD tasks complete (exit 2 if compound not run), and enforces Anti-Premature Completion Protocol — blocks if task marked complete without verification evidence (`verify-completion.sh`)
+- **PreToolUse(Bash):** Blocks destructive commands and detects proot environment. Package manager enforcement is project-aware (only blocks npm if pnpm-lock.yaml exists).
+- **PreToolUse(Write|Edit):** TDD enforcement — blocks production code edits if no corresponding test file exists (`check-test-exists.sh`). Language-universal: supports TS/JS, Python, Go, Rust, Ruby, Java, Kotlin, Elixir, Swift, Dart, C#, Scala, C/C++, Haskell, Zig. Write the test first.
+- **PostToolUse(Write|Edit):** Auto-formats code files using the detected formatter for the file's language (Biome/ESLint for JS/TS, ruff/black for Python, rustfmt for Rust, gofmt for Go, etc.). Skips silently if no formatter found; exit 2 on unfixable errors. Then verifies INVARIANTS.md rules — blocks if any machine-verifiable invariant is violated (`check-invariants.sh`).
+- **Stop:** Runs static type checking for the detected project language (tsc/tsgo for TypeScript, cargo check for Rust, go vet for Go, mypy/pyright for Python, etc.). Reminds to run /compound when PRD tasks complete (exit 2 if compound not run). Enforces Anti-Premature Completion Protocol — blocks if task marked complete without verification evidence (`verify-completion.sh`).
 - **Notification:** Desktop alert when agent needs attention (no-op in proot)
 
 Anti-Goodhart verification is enforced by sprint-executor Step 8, orchestrator Step 8.5, and plan-build-test Phase 5.5 — not by hooks.
@@ -356,7 +356,7 @@ Anti-Goodhart verification is enforced by sprint-executor Step 8, orchestrator S
 - **Hard block** (always denied): `rm -rf /`, `rm -rf` on system directories (`/etc`, `/usr`, `/var`, `/home`, etc.), `dd`, fork bombs
 - **Soft block** (warns and asks user for confirmation):
   - Destructive git: `git push --force`, `git push -f`, `git push --force-with-lease`, `git push ... main/master`, `git reset --hard`, `git checkout .`, `git restore .`, `git branch -D`, `git clean -f`, `git stash drop/clear`
-  - Forbidden package managers: `npm install/run/exec/start/test/build/ci/init`, `npx` — project uses pnpm exclusively
+  - Package manager mismatch: `npm`/`npx` blocked only when `pnpm-lock.yaml` exists (project-aware detection)
 
 Soft blocks exit 2 with a descriptive message — the user can re-approve if the operation is genuinely required.
 
@@ -656,24 +656,24 @@ After every task, evaluate whether documentation needs updating (part of compoun
 ## PROOT-DISTRO ARM64 ENVIRONMENT
 
 **Auto-detection:** If `uname -r` contains `PRoot-Distro` AND `uname -m` = `aarch64`, all rules in this section are ACTIVE. Three layers handle proot:
-- **settings.json env:** Sets `NODE_OPTIONS`, `CHOKIDAR_USEPOLLING`, `WATCHPACK_POLLING` globally (always active)
-- **proot-preflight.sh:** Runs on first Bash command per session; WARNS about disk, symlinks, SST locks, .npmrc (informational only, exit 0)
-- **worktree-preflight.sh:** Called by orchestrator Step 0; sets env vars and fixes deps for sprint execution
+- **settings.json env:** Sets `NODE_OPTIONS`, `CHOKIDAR_USEPOLLING`, `WATCHPACK_POLLING` globally (harmless for non-Node.js projects)
+- **proot-preflight.sh:** Runs on first Bash command per session; language-aware warnings (Node.js checks only run if package.json exists)
+- **worktree-preflight.sh:** Called by orchestrator Step 0; detects all project languages, sets env vars and installs deps per-language
 
-**Full reference:** `~/.claude/docs/proot-distro-environment.md`
+**Full reference:** `~/.claude/docs/proot-distro-environment.md` and `~/.claude/docs/universal-workflow-guide.md`
 
 ### Mandatory Rules (when proot-distro detected)
 
 1. **NEVER attempt `playwright install chromium`** or `browser_take_screenshot` — Chromium doesn't run in proot ARM64. Use `browser_snapshot` (accessibility tree) instead.
-2. **NEVER trust `pnpm install` blindly** — Check `.npmrc` for `node-linker=hoisted` first. After install, verify: `find node_modules/.bin -type l ! -exec test -e {} \; -print | head -5`
+2. **NEVER trust dependency install blindly** — For Node.js: check `.npmrc` for `node-linker=hoisted` first. After install, verify: `find node_modules/.bin -type l ! -exec test -e {} \; -print | head -5`
 3. **NEVER set tight timeouts** — Everything runs 2-5x slower. Multiply expected times by 3x minimum.
 4. **NEVER use Lighthouse/PageSpeed as quality gates** — Performance scores are unreliable in proot. Mark as `BLOCKED: proot-distro ARM64`.
 5. **NEVER rely on `inotify`** — Polling env vars are set globally in `settings.json`.
 6. **ALWAYS check for SST state locks** before deploy: `ls .sst/lock* 2>/dev/null`
-7. **NODE_OPTIONS is set globally** in `settings.json` — no manual export needed.
+7. **NODE_OPTIONS is set globally** in `settings.json` — no manual export needed (harmless for non-Node.js).
 8. **ALWAYS use retry-with-backoff for external APIs** — `source ~/.claude/hooks/retry-with-backoff.sh`
 
-### Known Native Module Failures
+### Known Native Module Failures (Node.js)
 
 These packages have native binaries that WILL fail in proot-distro:
 - `@parcel/watcher` → use `PARCEL_WATCHER_BACKEND=fs-events` or JS fallback
@@ -681,6 +681,15 @@ These packages have native binaries that WILL fail in proot-distro:
 - `sharp` → use JS-based image processing alternatives
 - `turbo` (native) → use non-native mode
 - Any `node-gyp` compilation → prefer JS alternatives
+
+### Proot Considerations for Other Languages
+
+| Language | Issue | Workaround |
+|----------|-------|------------|
+| Rust | Long compile times, may OOM | `cargo check` over `cargo build`, `codegen-units = 1` |
+| Go | `/proc/self/exe` → `/.l2s/` path translation | Copy resource files to `/.l2s/` |
+| Python | No known issues | Works well |
+| Java | JVM startup slow | Gradle daemon, increase memory |
 
 ### Go Binary /.l2s/ Fix
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,14 @@ The core loop. Plan + Review = 80% of effort. Work + Compound = 20%. The bottlen
 │   ├── compound/          # Post-task learning capture
 │   ├── workflow-audit/    # Periodic system self-review
 │   └── update-docs/       # Analyze code and update project documentation
-├── hooks/             # Safety enforcement scripts
-│   ├── block-dangerous.sh     # Blocks rm -rf, force push, npm
-│   ├── check-test-exists.sh   # TDD gate — blocks edits without test file
+├── hooks/             # Safety enforcement scripts (language-universal)
+│   ├── lib/
+│   │   └── detect-project.sh   # Shared language/project detection (16 languages)
+│   ├── block-dangerous.sh     # Blocks rm -rf, force push, project-aware pkg mgr
+│   ├── check-test-exists.sh   # TDD gate — blocks edits without test file (all langs)
 │   ├── check-invariants.sh    # Verifies INVARIANTS.md rules after edits
-│   ├── post-edit-quality.sh   # Auto-formats TS/JS after every edit
-│   ├── end-of-turn-typecheck.sh # Type-checks before session end
+│   ├── post-edit-quality.sh   # Auto-formats code after every edit (all langs)
+│   ├── end-of-turn-typecheck.sh # Static type checking (all langs)
 │   ├── compound-reminder.sh   # Blocks session end without learning capture
 │   ├── verify-completion.sh   # Blocks premature completion claims
 │   ├── validate-i18n-keys.sh  # Cross-validates i18n keys across locales
@@ -73,6 +75,7 @@ The core loop. Plan + Review = 80% of effort. Work + Compound = 20%. The bottlen
 │   ├── run-tests.sh           # Validates entire ~/.claude/ structure
 │   └── testdata/              # Fixture projects for hook behavioral tests
 ├── docs/              # Reference material (loaded on demand, not every session)
+│   ├── universal-workflow-guide.md  # How to use/extend for any language
 │   ├── evaluation-reference.md
 │   ├── anti-patterns-full.md
 │   ├── verification-gates.md
@@ -111,16 +114,22 @@ The system uses deterministic hooks — real code that runs before/after every a
 
 | Hook | Trigger | What It Does |
 |---|---|---|
-| `block-dangerous.sh` | Every Bash command | Blocks `rm -rf /`, force push, npm |
-| `check-test-exists.sh` | Every file edit | TDD gate — blocks production code edits without test file |
+| `block-dangerous.sh` | Every Bash command | Blocks `rm -rf /`, force push; project-aware package manager enforcement |
+| `check-test-exists.sh` | Every file edit | TDD gate — blocks production code edits without test file (16 languages) |
 | `check-invariants.sh` | Every file edit | Verifies INVARIANTS.md rules after edits |
-| `post-edit-quality.sh` | Every file edit | Auto-formats TS/JS (Biome or ESLint) |
-| `end-of-turn-typecheck.sh` | Session end | Type-checks TypeScript |
+| `post-edit-quality.sh` | Every file edit | Auto-formats code using detected formatter (Biome, ruff, rustfmt, gofmt, etc.) |
+| `end-of-turn-typecheck.sh` | Session end | Static type checking (tsc, cargo check, go vet, mypy, pyright, etc.) |
 | `compound-reminder.sh` | Session end | Blocks exit without learning capture |
 | `verify-completion.sh` | Session end | Blocks premature completion without evidence |
 | `validate-i18n-keys.sh` | Pre-commit (via ship-test-ensure) | Cross-validates all i18n t() keys exist in all locale files |
 | `verify-worktree-merge.sh` | Post-merge (via orchestrator) | Detects files silently overwritten by worktree merges |
 | `check-docs-updated.sh` | Every `git push` (PreToolUse) | Blocks push if hooks/skills/agents changed without doc updates |
+
+All hooks auto-detect the project's language(s) via `hooks/lib/detect-project.sh`. Adding support for a new language means updating one file — see [Universal Workflow Guide](docs/universal-workflow-guide.md).
+
+#### Supported Languages
+
+TypeScript, JavaScript, Python, Go, Rust, Ruby, Java, Kotlin, Elixir, Swift, Dart, C#, Scala, C/C++, Haskell, and Zig. Each language gets: TDD enforcement with idiomatic test patterns, auto-formatting with the project's configured tools, end-of-turn type/static checking, and language-aware dependency management in worktree preflight.
 
 ### Workflow Integrity Tests
 

--- a/docs/universal-workflow-guide.md
+++ b/docs/universal-workflow-guide.md
@@ -1,0 +1,330 @@
+# Universal Workflow Guide
+
+This workflow system is **language-agnostic by design**. It auto-detects your project's language(s) and adapts its behavior — TDD enforcement, auto-formatting, type checking, dependency management, and gitignore generation all work without configuration for supported languages.
+
+## Supported Languages (out of the box)
+
+| Language | Type Checker | Formatter | TDD Patterns | Dependency Mgmt |
+|----------|-------------|-----------|--------------|-----------------|
+| TypeScript | tsgo / tsc | Biome, ESLint, Prettier | `*.test.ts`, `*.spec.ts`, `__tests__/` | pnpm / yarn / npm / bun |
+| JavaScript | — | Biome, ESLint, Prettier | `*.test.js`, `*.spec.js`, `__tests__/` | pnpm / yarn / npm / bun |
+| Python | pyright, mypy | ruff, black, autopep8 | `test_*.py`, `*_test.py`, `tests/` | poetry, uv, pip, pipenv |
+| Go | go vet | goimports, gofmt | `*_test.go` | go mod download |
+| Rust | cargo check | rustfmt | `tests/*.rs`, inline `#[cfg(test)]` | cargo fetch |
+| Ruby | — | rubocop | `*_spec.rb`, `*_test.rb`, `spec/`, `test/` | bundle install |
+| Java | gradle/maven compile | google-java-format, spotless | `*Test.java`, `src/test/java/` | gradle / maven |
+| Kotlin | gradle compileKotlin | ktlint | `*Test.kt`, `src/test/kotlin/` | gradle |
+| Elixir | — | mix format | `*_test.exs`, `test/` | mix deps.get |
+| Swift | swift build | swift-format, swiftformat | `*Tests.swift`, `Tests/` | swift package resolve |
+| Dart | dart analyze | dart format | `*_test.dart`, `test/` | dart pub get |
+| C# | dotnet build | dotnet format | `*Tests.cs`, `*.Tests/` | dotnet restore |
+| Scala | sbt compile | scalafmt | `*Spec.scala`, `*Test.scala` | sbt update |
+| C / C++ | — | clang-format | `*_test.c`, `test/`, `tests/` | — |
+| Haskell | stack build / cabal | ormolu, fourmolu | `*Spec.hs`, `*Test.hs` | stack setup / cabal update |
+| Zig | zig build | zig fmt | inline `test "name" {}`, `test/` | — |
+
+## How Detection Works
+
+The system uses **marker files** to detect your project's language(s). No configuration required.
+
+### Marker Files → Language Detection
+
+| Marker File | Detected Language |
+|------------|-------------------|
+| `tsconfig.json` | TypeScript |
+| `package.json` (no tsconfig) | JavaScript |
+| `deno.json` / `deno.jsonc` | Deno |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `pyproject.toml` / `setup.py` / `requirements.txt` / `Pipfile` | Python |
+| `Gemfile` | Ruby |
+| `build.gradle` / `build.gradle.kts` / `pom.xml` | Java |
+| `build.gradle.kts` + `src/main/kotlin/` | Kotlin |
+| `mix.exs` | Elixir |
+| `Package.swift` | Swift |
+| `CMakeLists.txt` / `Makefile` / `meson.build` | C / C++ |
+| `build.zig` | Zig |
+| `pubspec.yaml` | Dart |
+| `*.csproj` / `*.sln` | C# |
+| `build.sbt` | Scala |
+| `stack.yaml` / `*.cabal` | Haskell |
+
+### Multi-Language Projects
+
+Projects can have **multiple languages** (e.g., a TypeScript frontend + Go backend). The system detects all of them. The hooks act per-file — a `.go` file triggers Go-specific behavior, a `.ts` file triggers TypeScript-specific behavior.
+
+## Architecture
+
+All language-specific logic is centralized in one file:
+
+```
+~/.claude/hooks/lib/detect-project.sh    ← ALL language detection lives here
+~/.claude/hooks/end-of-turn-typecheck.sh ← Stop hook: type checking (sources lib)
+~/.claude/hooks/post-edit-quality.sh     ← PostToolUse: auto-formatting (sources lib)
+~/.claude/hooks/check-test-exists.sh     ← PreToolUse: TDD enforcement (sources lib)
+~/.claude/hooks/check-invariants.sh      ← PostToolUse: invariant verification (sources lib)
+~/.claude/hooks/worktree-preflight.sh    ← Sprint prep: git + deps (sources lib)
+~/.claude/hooks/block-dangerous.sh       ← PreToolUse: safety gates
+~/.claude/hooks/proot-preflight.sh       ← PreToolUse: proot environment detection
+```
+
+### Hook → Library Function Mapping
+
+| Hook | Library Functions Used |
+|------|----------------------|
+| `end-of-turn-typecheck.sh` | `detect_project_langs`, `detect_typechecker`, `code_extensions_for_lang`, `detect_pkg_manager` |
+| `post-edit-quality.sh` | `is_code_file`, `is_generated_path`, `detect_formatter`, `detect_pkg_manager` |
+| `check-test-exists.sh` | `is_code_file`, `is_test_file`, `is_config_file`, `is_generated_path`, `is_entry_point`, `lang_for_extension`, `has_test_infra`, `find_test_candidates` |
+| `check-invariants.sh` | `is_code_file`, `is_generated_path` |
+| `worktree-preflight.sh` | `detect_project_langs`, `detect_pkg_manager`, `detect_dep_install_cmd` |
+
+## Adding a New Language
+
+To add support for a new language (e.g., Lua, PHP, Nim), edit **one file**: `~/.claude/hooks/lib/detect-project.sh`.
+
+### Step-by-step
+
+#### 1. File Extension Mapping
+
+In `lang_for_extension()`, add your extension → language mapping:
+
+```bash
+lang_for_extension() {
+  case "$1" in
+    # ... existing entries ...
+    nim)          echo "nim" ;;      # ← ADD THIS
+    *)            echo "" ;;
+  esac
+}
+```
+
+#### 2. Project Detection
+
+In `detect_project_langs()`, add marker file detection:
+
+```bash
+detect_project_langs() {
+  # ... existing entries ...
+
+  # Nim
+  [ -f "$dir/nim.cfg" ] || [ -f "$dir/*.nimble" ] && PROJECT_LANGS+=("nim")
+}
+```
+
+#### 3. Test File Patterns
+
+In `is_test_file()`, add test file naming conventions:
+
+```bash
+is_test_file() {
+  # ... existing entries ...
+  nim)
+    case "$basename" in
+      test_*|t_*) return 0 ;;
+    esac
+    case "$filepath" in
+      */tests/*|*/test/*) return 0 ;;
+    esac
+    ;;
+}
+```
+
+#### 4. Test Candidates
+
+In `find_test_candidates()`, add where tests might live:
+
+```bash
+find_test_candidates() {
+  # ... existing entries ...
+  nim)
+    TEST_CANDIDATES+=(
+      "$project_dir/tests/test_${filename}.nim"
+      "$project_dir/tests/t_${filename}.nim"
+      "$dirname/test_${filename}.nim"
+    )
+    ;;
+}
+```
+
+#### 5. Test Infrastructure Detection
+
+In `has_test_infra()`, add how to detect if tests are set up:
+
+```bash
+has_test_infra() {
+  # ... existing entries ...
+  nim|"")
+    [ -d "$dir/tests" ] && return 0
+    [ -n "$lang" ] && return 1
+    ;;&
+}
+```
+
+#### 6. Formatter Detection
+
+In `detect_formatter()`, add formatter/linter support:
+
+```bash
+detect_formatter() {
+  # ... existing entries ...
+  nim)
+    if command -v nimpretty &>/dev/null; then
+      FORMATTER_CMD="nimpretty"
+    fi
+    ;;
+}
+```
+
+#### 7. Type Checker Detection
+
+In `detect_typechecker()`, add compile/check command:
+
+```bash
+detect_typechecker() {
+  # ... existing entries ...
+  nim)
+    if command -v nim &>/dev/null; then
+      TYPECHECKER_NAME="nim check"
+      TYPECHECKER_CMD="nim check"
+    fi
+    ;;
+}
+```
+
+#### 8. Dependency Management
+
+In `detect_dep_install_cmd()`, add dependency install command:
+
+```bash
+detect_dep_install_cmd() {
+  # ... existing entries ...
+  nim)
+    if command -v nimble &>/dev/null; then
+      DEP_INSTALL_CMD="nimble install -d"
+    fi
+    DEP_LANG="nim"
+    [ -n "$DEP_INSTALL_CMD" ] && return 0
+    ;;
+}
+```
+
+#### 9. Generated Directories
+
+In `is_generated_path()`, add build output directories:
+
+```bash
+is_generated_path() {
+  # ... existing entries ...
+  # Nim
+  */nimcache/*) return 0 ;;
+}
+```
+
+#### 10. Config Files (optional)
+
+In `is_config_file()`, add config file names:
+
+```bash
+is_config_file() {
+  # ... existing entries ...
+  *.nimble|nim.cfg) return 0 ;;
+}
+```
+
+#### 11. Entry Points (optional)
+
+In `is_entry_point()`, add main/entry file names:
+
+```bash
+is_entry_point() {
+  # ... existing entries ...
+  main.nim) return 0 ;;
+}
+```
+
+### After Adding
+
+1. **Test the hook chain**: Edit a file of the new language and verify:
+   - `check-test-exists.sh` enforces TDD (blocks without test file)
+   - `post-edit-quality.sh` runs the formatter (if available)
+   - `end-of-turn-typecheck.sh` runs the type checker (at end of turn)
+   - `check-invariants.sh` recognizes the file as code
+
+2. **Test worktree-preflight**: Run it in a project directory and verify dependency detection:
+   ```bash
+   bash ~/.claude/hooks/worktree-preflight.sh
+   ```
+
+3. **Optionally add to worktree-preflight.sh**: If the language needs specific `.gitignore` entries or dependency management in the worktree bootstrap, add a case block there.
+
+## Project-Level Configuration
+
+For project-specific settings that override defaults, use the project's `CLAUDE.md` file:
+
+```markdown
+## Execution Config
+
+- **Package manager:** pnpm
+- **Test command:** pnpm vitest run
+- **Lint command:** pnpm biome check
+- **Build command:** pnpm build
+- **Type check command:** pnpm tsc --noEmit
+```
+
+Skills (`/plan-build-test`, `/ship-test-ensure`) read from `## Execution Config`. The hooks auto-detect without configuration — project CLAUDE.md is for overrides and skill-level commands.
+
+## Settings.json Environment Variables
+
+The `settings.json` env section contains Node.js-specific variables:
+
+```json
+{
+  "env": {
+    "NODE_OPTIONS": "--max-old-space-size=2048",
+    "CHOKIDAR_USEPOLLING": "true",
+    "WATCHPACK_POLLING": "true"
+  }
+}
+```
+
+These are harmless for non-Node.js projects (they're only read by Node.js processes). If you're never working on Node.js projects, you can remove them.
+
+To add environment variables for other languages, add them here:
+
+```json
+{
+  "env": {
+    "RUST_BACKTRACE": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "GOFLAGS": "-count=1"
+  }
+}
+```
+
+## proot-distro ARM64 Considerations
+
+Some language toolchains have known issues in proot-distro ARM64:
+
+| Language | Issue | Workaround |
+|----------|-------|------------|
+| Node.js | Native modules fail (@parcel/watcher, sharp, turbo) | Use JS fallbacks, `--ignore-scripts` |
+| Rust | Long compile times, may OOM | Use `cargo check` instead of `cargo build`, set `codegen-units = 1` |
+| Go | `/proc/self/exe` → `/.l2s/` translation | Copy required resource files to `/.l2s/` |
+| Python | No known issues | Works well in proot |
+| Java | JVM startup is slow | Use Gradle daemon, increase memory |
+| C/C++ | Native compilation works | No issues known |
+
+## Workflow Components That Are 100% Language-Agnostic
+
+These require zero changes regardless of language:
+
+- **PRD system** — Plan/Sprint decomposition
+- **INVARIANTS.md** — Cross-module contracts (verify commands are shell commands)
+- **Contract-First pattern** — Intent → Mirror → Receipt
+- **Judgment protocols** — Confidence levels, risk categories
+- **Anti-Premature Completion** — Verification checklist
+- **Session Learnings** — Error/pattern capture
+- **Compound Engineering** — Post-task learning loop
+- **Verification Pattern** — Prose spec + executable tests + iteration loops
+- **Git workflow** — Branching, commits, PRs
+- **Agent architecture** — Orchestrator, sprint-executor, code-reviewer

--- a/hooks/block-dangerous.sh
+++ b/hooks/block-dangerous.sh
@@ -132,14 +132,19 @@ if [[ "$COMMAND" =~ git[[:space:]]+stash[[:space:]]+(drop|clear) ]]; then
   deny "SOFT BLOCK: git stash drop/clear — permanently discards stashed changes. Re-approve if intentional."
 fi
 
-# === SOFT BLOCKS: npm/npx ===
+# === SOFT BLOCKS: Package manager enforcement ===
+# Only block npm/npx if the project explicitly uses pnpm (detected by lockfile).
+# This prevents forcing pnpm on projects that use npm, yarn, or bun.
 
-if [[ "$COMMAND" =~ (^|[[:space:]])npm[[:space:]]+(install|run|exec|start|test|build|ci|init)([[:space:]]|$) ]]; then
-  deny "SOFT BLOCK: npm detected — this project uses pnpm exclusively. Use pnpm instead."
-fi
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD:-$(pwd)}}"
+if [ -f "$PROJECT_DIR/pnpm-lock.yaml" ] || [ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]; then
+  if [[ "$COMMAND" =~ (^|[[:space:]])npm[[:space:]]+(install|run|exec|start|test|build|ci|init)([[:space:]]|$) ]]; then
+    deny "SOFT BLOCK: npm detected — this project uses pnpm (pnpm-lock.yaml found). Use pnpm instead."
+  fi
 
-if [[ "$COMMAND" =~ (^|[[:space:]])npx[[:space:]]+ ]]; then
-  deny "SOFT BLOCK: npx detected — this project uses pnpm exclusively. Use pnpm dlx instead."
+  if [[ "$COMMAND" =~ (^|[[:space:]])npx[[:space:]]+ ]]; then
+    deny "SOFT BLOCK: npx detected — this project uses pnpm (pnpm-lock.yaml found). Use pnpm dlx instead."
+  fi
 fi
 
 # All checks passed

--- a/hooks/check-invariants.sh
+++ b/hooks/check-invariants.sh
@@ -53,17 +53,18 @@ if [[ "$FILE_PATH" != /* ]]; then
   FILE_PATH="$PROJECT_DIR/$FILE_PATH"
 fi
 
+# Source shared detection library for is_code_file and is_generated_path
+source ~/.claude/hooks/lib/detect-project.sh
+
 # Skip non-code files (invariant checks only matter for source code)
-case "$FILE_PATH" in
-  *.ts|*.tsx|*.js|*.jsx|*.py|*.go|*.rs|*.java|*.rb|*.php) ;;
-  *) exit 0 ;;
-esac
+if ! is_code_file "$FILE_PATH"; then
+  exit 0
+fi
 
 # Skip generated/vendor directories
-case "$FILE_PATH" in
-  */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/coverage/*) exit 0 ;;
-  */.turbo/*|*/__generated__/*|*/.generated/*|*/generated/*) exit 0 ;;
-esac
+if is_generated_path "$FILE_PATH"; then
+  exit 0
+fi
 
 # === COLLECT INVARIANT FILES ===
 # Walk from the edited file's directory up to the project root,

--- a/hooks/check-test-exists.sh
+++ b/hooks/check-test-exists.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 # PreToolUse(Write|Edit) hook: Enforce TDD by blocking production code edits
 # when no corresponding test file exists.
 #
-# Inspired by Jason Vertrees' "check-test-exists.sh" pattern from
-# "From Vibe Coding to Agentic Engineering" — promotes TDD from a soft
-# instruction to a hard gate. The agent CANNOT skip writing the failing test first.
+# Language-universal — supports all major languages via lib/detect-project.sh.
+#
+# To add a new language: update is_test_file(), find_test_candidates(),
+# and has_test_infra() in lib/detect-project.sh.
 #
 # Exit codes:
 #   0 — allow (test exists, or file is not production code)
@@ -40,162 +41,58 @@ if [[ "$FILE_PATH" != /* ]]; then
   FILE_PATH="$PROJECT_DIR/$FILE_PATH"
 fi
 
+# Source shared detection library
+source ~/.claude/hooks/lib/detect-project.sh
+
 # === SKIP CONDITIONS ===
 
-# Skip non-code files (only enforce for TS/JS/Python/Go source)
-case "$FILE_PATH" in
-  *.ts|*.tsx|*.js|*.jsx|*.py|*.go) ;;
-  *) exit 0 ;;
-esac
+# Skip non-code files
+if ! is_code_file "$FILE_PATH"; then
+  exit 0
+fi
 
 # Skip files that ARE test files already
-case "$FILE_PATH" in
-  *.test.ts|*.test.tsx|*.test.js|*.test.jsx|*.spec.ts|*.spec.tsx|*.spec.js|*.spec.jsx)
-    exit 0 ;;
-  *_test.py|*_test.go)
-    exit 0 ;;
-  */test_*.py)
-    exit 0 ;;
-  */__tests__/*)
-    exit 0 ;;
-  */tests/*|*/test/*)
-    exit 0 ;;
-esac
+if is_test_file "$FILE_PATH"; then
+  exit 0
+fi
 
 # Skip config, setup, and infrastructure files
-case "$FILE_PATH" in
-  *.config.*|*.setup.*|*vite.config*|*next.config*|*tailwind.config*)
-    exit 0 ;;
-  */migrations/*|*/seeds/*|*/fixtures/*|*/scripts/*|*/bin/*)
-    exit 0 ;;
-  *conftest.py|*setup.py|*setup.cfg|*pyproject.toml)
-    exit 0 ;;
-esac
+if is_config_file "$FILE_PATH"; then
+  exit 0
+fi
 
-# Skip generated, build, and vendor directories
-case "$FILE_PATH" in
-  */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/coverage/*) exit 0 ;;
-  */.turbo/*|*/__generated__/*|*/.generated/*|*/generated/*) exit 0 ;;
-  */.cache/*|*/.output/*|*/.sst/*|*/.vercel/*) exit 0 ;;
-esac
+# Skip generated/vendor/build directories
+if is_generated_path "$FILE_PATH"; then
+  exit 0
+fi
 
-# Skip type declaration files, barrel exports, and entry points
+# Skip type declaration files (TypeScript)
 case "$FILE_PATH" in
   *.d.ts) exit 0 ;;
-  */index.ts|*/index.tsx|*/index.js|*/index.jsx) exit 0 ;;
-  */main.ts|*/main.tsx|*/main.js|*/main.jsx) exit 0 ;;
-  */app.ts|*/app.tsx|*/app.js|*/app.jsx) exit 0 ;;
-  */__init__.py) exit 0 ;;
 esac
 
-# Skip CSS/style-only files (some have .ts extension for CSS-in-JS)
+# Skip CSS/style-only files
 case "$FILE_PATH" in
   *.css|*.scss|*.less|*.styles.ts|*.styled.ts) exit 0 ;;
 esac
 
-# Skip documentation and non-logic files
-case "$FILE_PATH" in
-  *.md|*.txt|*.rst|*.json|*.yaml|*.yml|*.toml|*.env*) exit 0 ;;
-  */docs/*|*/documentation/*) exit 0 ;;
-  *Dockerfile*|*docker-compose*|*.dockerignore) exit 0 ;;
-  *Makefile|*.mk) exit 0 ;;
-esac
-
-# Skip if the project has no test infrastructure at all
-# (don't block on projects that haven't set up testing yet)
-HAS_TEST_INFRA=false
-for marker in \
-  "$PROJECT_DIR/jest.config"* \
-  "$PROJECT_DIR/vitest.config"* \
-  "$PROJECT_DIR/pytest.ini" \
-  "$PROJECT_DIR/pyproject.toml" \
-  "$PROJECT_DIR/setup.cfg" \
-  "$PROJECT_DIR/go.mod"; do
-  if [ -f "$marker" ] 2>/dev/null; then
-    HAS_TEST_INFRA=true
-    break
-  fi
-done
-
-# Also check package.json for test scripts
-if [ "$HAS_TEST_INFRA" = false ] && [ -f "$PROJECT_DIR/package.json" ]; then
-  if command -v jq &>/dev/null; then
-    if jq -e '.scripts.test // .devDependencies.jest // .devDependencies.vitest // .devDependencies.mocha' "$PROJECT_DIR/package.json" &>/dev/null; then
-      HAS_TEST_INFRA=true
-    fi
-  elif grep -q '"test"' "$PROJECT_DIR/package.json" 2>/dev/null; then
-    HAS_TEST_INFRA=true
-  fi
+# Skip entry points (index.ts, main.rs, __init__.py, etc.)
+if is_entry_point "$FILE_PATH"; then
+  exit 0
 fi
 
-if [ "$HAS_TEST_INFRA" = false ]; then
+# Detect the file's language
+EXT="${FILE_PATH##*.}"
+FILE_LANG=$(lang_for_extension "$EXT")
+
+# Skip if the project has no test infrastructure for this language
+if ! has_test_infra "$PROJECT_DIR" "$FILE_LANG"; then
   exit 0
 fi
 
 # === TEST FILE DISCOVERY ===
 
-# Extract file components
-DIRNAME=$(dirname "$FILE_PATH")
-BASENAME=$(basename "$FILE_PATH")
-FILENAME="${BASENAME%.*}"
-EXTENSION="${BASENAME##*.}"
-
-# Build list of possible test file locations
-TEST_CANDIDATES=()
-
-case "$EXTENSION" in
-  ts|tsx|js|jsx)
-    # Same directory: foo.test.ts, foo.spec.ts
-    TEST_CANDIDATES+=(
-      "$DIRNAME/${FILENAME}.test.${EXTENSION}"
-      "$DIRNAME/${FILENAME}.spec.${EXTENSION}"
-    )
-    # For tsx -> test.tsx, for ts -> test.ts
-    if [ "$EXTENSION" = "tsx" ]; then
-      TEST_CANDIDATES+=("$DIRNAME/${FILENAME}.test.tsx" "$DIRNAME/${FILENAME}.spec.tsx")
-    fi
-    if [ "$EXTENSION" = "ts" ]; then
-      TEST_CANDIDATES+=("$DIRNAME/${FILENAME}.test.ts" "$DIRNAME/${FILENAME}.spec.ts")
-    fi
-    # __tests__ directory
-    TEST_CANDIDATES+=(
-      "$DIRNAME/__tests__/${FILENAME}.test.${EXTENSION}"
-      "$DIRNAME/__tests__/${FILENAME}.spec.${EXTENSION}"
-    )
-    # Parent __tests__
-    PARENT=$(dirname "$DIRNAME")
-    TEST_CANDIDATES+=(
-      "$PARENT/__tests__/${FILENAME}.test.${EXTENSION}"
-      "$PARENT/__tests__/${FILENAME}.spec.${EXTENSION}"
-    )
-    # tests/ directory at project root
-    # Strip project dir prefix to get relative path
-    REL_PATH="${FILE_PATH#$PROJECT_DIR/}"
-    REL_DIR=$(dirname "$REL_PATH")
-    TEST_CANDIDATES+=(
-      "$PROJECT_DIR/tests/${REL_DIR}/${FILENAME}.test.${EXTENSION}"
-      "$PROJECT_DIR/test/${REL_DIR}/${FILENAME}.test.${EXTENSION}"
-    )
-    ;;
-  py)
-    # Same directory: test_foo.py, foo_test.py
-    TEST_CANDIDATES+=(
-      "$DIRNAME/test_${FILENAME}.py"
-      "$DIRNAME/${FILENAME}_test.py"
-    )
-    # tests/ directory at project root
-    REL_PATH="${FILE_PATH#$PROJECT_DIR/}"
-    REL_DIR=$(dirname "$REL_PATH")
-    TEST_CANDIDATES+=(
-      "$PROJECT_DIR/tests/test_${FILENAME}.py"
-      "$PROJECT_DIR/tests/${REL_DIR}/test_${FILENAME}.py"
-    )
-    ;;
-  go)
-    # Go: test file is always same directory, same package
-    TEST_CANDIDATES+=("$DIRNAME/${FILENAME}_test.go")
-    ;;
-esac
+find_test_candidates "$FILE_PATH" "$PROJECT_DIR"
 
 # Check if any test file exists
 for candidate in "${TEST_CANDIDATES[@]}"; do
@@ -204,10 +101,28 @@ for candidate in "${TEST_CANDIDATES[@]}"; do
   fi
 done
 
+# === RUST SPECIAL CASE: inline tests ===
+# Rust commonly uses #[cfg(test)] mod tests { ... } in the same file.
+# If the source file exists and contains inline tests, allow the edit.
+if [ "$FILE_LANG" = "rust" ] && [ -f "$FILE_PATH" ]; then
+  if grep -q '#\[cfg(test)\]' "$FILE_PATH" 2>/dev/null; then
+    exit 0
+  fi
+fi
+
+# === ZIG SPECIAL CASE: inline tests ===
+# Zig uses `test "name" { ... }` blocks inline.
+if [ "$FILE_LANG" = "zig" ] && [ -f "$FILE_PATH" ]; then
+  if grep -q '^test "' "$FILE_PATH" 2>/dev/null; then
+    exit 0
+  fi
+fi
+
 # No test file found — BLOCK
 {
   echo "BLOCKED: TDD enforcement — no test file found for production code."
   echo "File: $FILE_PATH"
+  echo "Language: ${FILE_LANG:-unknown}"
   echo ""
   echo "Write the test file FIRST (Red step), then edit the production code."
   echo "Expected test file in one of:"
@@ -215,6 +130,12 @@ done
   for candidate in "${TEST_CANDIDATES[@]:0:4}"; do
     echo "  - ${candidate#$PROJECT_DIR/}"
   done
+  if [ "$FILE_LANG" = "rust" ]; then
+    echo "  - Or add #[cfg(test)] mod tests { ... } inline in the source file"
+  fi
+  if [ "$FILE_LANG" = "zig" ]; then
+    echo "  - Or add test \"name\" { ... } inline in the source file"
+  fi
   echo ""
   echo "To skip: this file may need to be added to the skip list in check-test-exists.sh"
 } >&2

--- a/hooks/end-of-turn-typecheck.sh
+++ b/hooks/end-of-turn-typecheck.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Stop hook: Run static type checking at end of turn.
+#
+# Language-universal — auto-detects project type and runs the appropriate
+# type checker. Supports TypeScript, Python, Go, Rust, Java, Kotlin, Dart,
+# C#, Scala, Haskell, Swift, and Zig out of the box.
+#
+# To add a new language: update detect_typechecker() and
+# code_extensions_for_lang() in lib/detect-project.sh.
+#
+# Exit codes:
+#   0 — type check passed (or skipped)
+#   2 — type errors found
+
 # Check for jq
 if ! command -v jq &>/dev/null; then
   echo "ERROR: jq is required but not installed. Run: apt install jq" >&2
@@ -19,33 +32,45 @@ fi
 # Resolve project directory
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# Check for tsconfig.json
-if [ ! -f "$PROJECT_DIR/tsconfig.json" ]; then
+# Source shared detection library
+source ~/.claude/hooks/lib/detect-project.sh
+
+# Detect project languages
+detect_project_langs "$PROJECT_DIR"
+if [ ${#PROJECT_LANGS[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Ensure log directory and log file exist (log file needed for -newer comparison)
+# Ensure log directory and log file exist
 LOG_DIR="$(eval echo ~)/.claude/hooks/logs"
 mkdir -p "$LOG_DIR"
 [ -f "$LOG_DIR/typecheck.log" ] || touch "$LOG_DIR/typecheck.log"
 
-# Skip if no code was written this turn (no Write/Edit tool used)
-# The hook input contains tool_results from the turn — check for Write/Edit usage
+# Skip if no code was written this turn
 WROTE_CODE=$(echo "$INPUT" | jq -r '
   .transcript // [] | map(select(
     .tool_name == "Write" or .tool_name == "Edit" or .tool_name == "MultiEdit"
   )) | length
 ' 2>/dev/null || echo "0")
-# If jq parsing fails or returns 0, also check a simpler heuristic:
-# look for recent file modifications in the project (last 2 minutes)
+
 if [ "$WROTE_CODE" = "0" ]; then
-  RECENT_CHANGES=$(find "$PROJECT_DIR" \( -name "*.ts" -o -name "*.tsx" \) -newer "$LOG_DIR/typecheck.log" 2>/dev/null | head -1)
+  # Check for recent file modifications as fallback
+  RECENT_CHANGES=""
+  for lang in "${PROJECT_LANGS[@]}"; do
+    EXT_PATTERN=$(code_extensions_for_lang "$lang")
+    if [ -n "$EXT_PATTERN" ]; then
+      RECENT_CHANGES=$(eval "find '$PROJECT_DIR' \( $EXT_PATTERN \) -newer '$LOG_DIR/typecheck.log'" 2>/dev/null | head -1) || true
+      [ -n "$RECENT_CHANGES" ] && break
+    fi
+  done
   if [ -z "$RECENT_CHANGES" ]; then
     exit 0
   fi
 fi
 
-# Find the native tsgo binary (not the Node.js shim)
+# ─── TYPESCRIPT-SPECIFIC: tsgo native binary detection ─────────────────
+# This optimization is TypeScript-only (tsgo is a native Go binary for TS).
+
 find_tsgo_native() {
   local PROJ="$1"
   local PLATFORM="linux"
@@ -58,13 +83,11 @@ find_tsgo_native() {
   esac
 
   local PKG_NAME="native-preview-${PLATFORM}-${ARCH}"
-  # Check direct node_modules path first (fastest)
   local DIRECT="$PROJ/node_modules/@typescript/${PKG_NAME}/lib/tsgo"
   if [ -x "$DIRECT" ]; then
     echo "$DIRECT"
     return 0
   fi
-  # Search in pnpm store structure (pnpm uses @scope+pkg@ver in .pnpm dir)
   local SEARCH_DIR="$PROJ/node_modules/.pnpm"
   if [ -d "$SEARCH_DIR" ]; then
     local FOUND
@@ -77,70 +100,90 @@ find_tsgo_native() {
   return 1
 }
 
-# Ensure proot-distro compatibility: copy lib .d.ts files to /.l2s/ if needed
-# (proot translates /proc/self/exe to /.l2s/ paths, Go binaries resolve libs relative to exe)
 ensure_proot_tsgo_compat() {
   local TSGO_BIN="$1"
   local LIB_DIR
   LIB_DIR=$(dirname "$TSGO_BIN")
-
-  # Only needed if /.l2s/ exists (proot-distro environment)
   if [ -d "/.l2s" ] && [ -f "$LIB_DIR/lib.d.ts" ]; then
-    # Check if lib.d.ts is already there and current
     if [ ! -f "/.l2s/lib.d.ts" ] || [ "$LIB_DIR/lib.d.ts" -nt "/.l2s/lib.d.ts" ]; then
       cp "$LIB_DIR"/lib*.d.ts /.l2s/ 2>/dev/null || true
     fi
   fi
 }
 
-# Determine type checker
+# ─── RESOLVE TYPE CHECKER ──────────────────────────────────────────────
+
 TOOL_NAME=""
 TOOL_CMD=""
 
-# Use cached tsgo path if valid (avoids expensive `find` in proot-distro)
-TSGO_CACHE="$LOG_DIR/.tsgo_cache_$(echo "$PROJECT_DIR" | md5sum | cut -d' ' -f1)"
-TSGO_NATIVE=""
-if [ -f "$TSGO_CACHE" ]; then
-  CACHED=$(cat "$TSGO_CACHE")
-  if [ -x "$CACHED" ]; then
-    TSGO_NATIVE="$CACHED"
-  else
-    rm -f "$TSGO_CACHE"
-  fi
-fi
-if [ -z "$TSGO_NATIVE" ]; then
-  TSGO_NATIVE=$(find_tsgo_native "$PROJECT_DIR" 2>/dev/null) || true
-  if [ -n "$TSGO_NATIVE" ]; then
-    echo "$TSGO_NATIVE" > "$TSGO_CACHE"
-  fi
+for lang in "${PROJECT_LANGS[@]}"; do
+  case "$lang" in
+    typescript)
+      # TypeScript has special tsgo optimization
+      TSGO_CACHE="$LOG_DIR/.tsgo_cache_$(echo "$PROJECT_DIR" | md5sum | cut -d' ' -f1)"
+      TSGO_NATIVE=""
+      if [ -f "$TSGO_CACHE" ]; then
+        CACHED=$(cat "$TSGO_CACHE")
+        if [ -x "$CACHED" ]; then
+          TSGO_NATIVE="$CACHED"
+        else
+          rm -f "$TSGO_CACHE"
+        fi
+      fi
+      if [ -z "$TSGO_NATIVE" ]; then
+        TSGO_NATIVE=$(find_tsgo_native "$PROJECT_DIR" 2>/dev/null) || true
+        if [ -n "$TSGO_NATIVE" ]; then
+          echo "$TSGO_NATIVE" > "$TSGO_CACHE"
+        fi
+      fi
+
+      if [ -n "$TSGO_NATIVE" ]; then
+        ensure_proot_tsgo_compat "$TSGO_NATIVE"
+        TOOL_NAME="tsgo (native)"
+        TOOL_CMD="$TSGO_NATIVE"
+      elif command -v tsgo &>/dev/null; then
+        TOOL_NAME="tsgo (global)"
+        TOOL_CMD="tsgo"
+      else
+        detect_pkg_manager "$PROJECT_DIR"
+        TOOL_NAME="tsc"
+        TOOL_CMD="${PKG_MGR:-npx} tsc --noEmit --skipLibCheck"
+      fi
+      break
+      ;;
+    *)
+      # All other languages use the generic detector
+      detect_typechecker "$PROJECT_DIR" "$lang"
+      if [ -n "$TYPECHECKER_CMD" ]; then
+        TOOL_NAME="$TYPECHECKER_NAME"
+        TOOL_CMD="$TYPECHECKER_CMD"
+        break
+      fi
+      ;;
+  esac
+done
+
+# No type checker found — exit silently
+if [ -z "$TOOL_CMD" ]; then
+  exit 0
 fi
 
-if [ -n "$TSGO_NATIVE" ]; then
-  ensure_proot_tsgo_compat "$TSGO_NATIVE"
-  TOOL_NAME="tsgo (native)"
-  TOOL_CMD="$TSGO_NATIVE"
-elif command -v tsgo &>/dev/null; then
-  TOOL_NAME="tsgo (global)"
-  TOOL_CMD="tsgo"
-else
-  TOOL_NAME="tsc"
-  TOOL_CMD="pnpm tsc --noEmit --skipLibCheck"
-fi
+# ─── RUN TYPE CHECKER ──────────────────────────────────────────────────
 
-# Run type checker and capture output
 START_NS=$(date +%s%N)
 TYPECHECK_OUTPUT=""
 TYPECHECK_EXIT=0
 
-TYPECHECK_OUTPUT=$(cd "$PROJECT_DIR" && $TOOL_CMD 2>&1) || TYPECHECK_EXIT=$?
+TYPECHECK_OUTPUT=$(cd "$PROJECT_DIR" && eval $TOOL_CMD 2>&1) || TYPECHECK_EXIT=$?
 
-# If tsgo crashed (panic, segfault, etc.) rather than reporting type errors, fall back to tsc
-if [ "$TOOL_NAME" != "tsc" ] && [ "$TYPECHECK_EXIT" -ne 0 ]; then
+# TypeScript-specific: if tsgo crashed, fall back to tsc
+if [[ "$TOOL_NAME" == tsgo* ]] && [ "$TYPECHECK_EXIT" -ne 0 ]; then
   if echo "$TYPECHECK_OUTPUT" | grep -qiE 'panic:|segfault|SIGSEGV|does not exist.*misplaced'; then
+    detect_pkg_manager "$PROJECT_DIR"
     TOOL_NAME="tsc (fallback from tsgo crash)"
-    TOOL_CMD="pnpm tsc --noEmit --skipLibCheck"
+    TOOL_CMD="${PKG_MGR:-npx} tsc --noEmit --skipLibCheck"
     TYPECHECK_EXIT=0
-    TYPECHECK_OUTPUT=$(cd "$PROJECT_DIR" && $TOOL_CMD 2>&1) || TYPECHECK_EXIT=$?
+    TYPECHECK_OUTPUT=$(cd "$PROJECT_DIR" && eval $TOOL_CMD 2>&1) || TYPECHECK_EXIT=$?
   fi
 fi
 

--- a/hooks/lib/detect-project.sh
+++ b/hooks/lib/detect-project.sh
@@ -1,0 +1,1068 @@
+#!/usr/bin/env bash
+# Shared project/language detection utilities for Claude Code hooks.
+#
+# Source this file from any hook:
+#   HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$HOOK_DIR/lib/detect-project.sh" 2>/dev/null || source ~/.claude/hooks/lib/detect-project.sh
+#
+# === EXTENDING FOR A NEW LANGUAGE ===
+# To add support for a new language/ecosystem:
+#   1. Add file extensions to lang_for_extension()
+#   2. Add marker file detection to detect_project_langs()
+#   3. Add test file patterns to is_test_file() and find_test_candidates()
+#   4. Add test infrastructure markers to has_test_infra()
+#   5. Add formatter/linter detection to detect_formatter()
+#   6. Add type checker detection to detect_typechecker()
+#   7. Add dependency install logic to detect_dep_install_cmd()
+#   8. Add generated/build directory patterns to is_generated_path()
+#   9. Add config/setup file patterns to is_config_file()
+#  10. Add entry point patterns to is_entry_point()
+#
+# Each function documents its output variables. All functions are idempotent.
+
+# ─── FILE CLASSIFICATION ───────────────────────────────────────────────
+
+# Maps a file extension to a language identifier.
+# Usage: LANG=$(lang_for_extension "ts")
+lang_for_extension() {
+  case "$1" in
+    ts|tsx)       echo "typescript" ;;
+    js|jsx|mjs|cjs) echo "javascript" ;;
+    py|pyi)       echo "python" ;;
+    go)           echo "go" ;;
+    rs)           echo "rust" ;;
+    rb)           echo "ruby" ;;
+    java)         echo "java" ;;
+    kt|kts)       echo "kotlin" ;;
+    scala|sc)     echo "scala" ;;
+    ex|exs)       echo "elixir" ;;
+    swift)        echo "swift" ;;
+    c|h)          echo "c" ;;
+    cpp|cc|cxx|hpp|hxx) echo "cpp" ;;
+    cs)           echo "csharp" ;;
+    php)          echo "php" ;;
+    zig)          echo "zig" ;;
+    lua)          echo "lua" ;;
+    hs)           echo "haskell" ;;
+    dart)         echo "dart" ;;
+    *)            echo "" ;;
+  esac
+}
+
+# Returns 0 if the file extension is a known code file.
+# Usage: is_code_file "src/main.rs" && echo "yes"
+is_code_file() {
+  local ext="${1##*.}"
+  local lang
+  lang=$(lang_for_extension "$ext")
+  [ -n "$lang" ]
+}
+
+# Returns 0 if the path is inside a generated, vendor, or build directory.
+# Usage: is_generated_path "/project/node_modules/foo.js" && echo "skip"
+is_generated_path() {
+  # Normalize: ensure path starts with / for consistent matching
+  local p="/$1"
+  case "$p" in
+    # Universal
+    */vendor/*|*/.git/*) return 0 ;;
+    # Node.js / JavaScript / TypeScript
+    */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/coverage/*) return 0 ;;
+    */.turbo/*|*/__generated__/*|*/.generated/*|*/generated/*) return 0 ;;
+    */.cache/*|*/.output/*|*/.nuxt/*|*/.svelte-kit/*|*/.vercel/*) return 0 ;;
+    */.graphql/*|*/graphql/generated/*|*/.prisma/*|*/prisma/generated/*) return 0 ;;
+    */.storybook/static/*|*/out/*|*/.parcel-cache/*|*/.turbopack/*) return 0 ;;
+    # Python
+    */__pycache__/*|*/.mypy_cache/*|*/.pytest_cache/*|*/.ruff_cache/*) return 0 ;;
+    */*.egg-info/*|*/.eggs/*|*/.tox/*|*/.nox/*|*/.venv/*|*/venv/*) return 0 ;;
+    */site-packages/*) return 0 ;;
+    # Rust
+    */target/debug/*|*/target/release/*|*/target/doc/*) return 0 ;;
+    # Go
+    */go/pkg/*) return 0 ;;
+    # Java / Kotlin / Scala
+    */target/classes/*|*/build/classes/*|*/build/libs/*) return 0 ;;
+    */.gradle/*) return 0 ;;
+    # C / C++
+    */cmake-build-*/*) return 0 ;;
+    # Dart / Flutter
+    */.dart_tool/*|*/build/flutter_assets/*) return 0 ;;
+    # Elixir
+    */_build/*|*/deps/*) return 0 ;;
+    # .NET / C#
+    */bin/Debug/*|*/bin/Release/*|*/obj/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Returns 0 if the file is a config/setup/infrastructure file (not business logic).
+# Usage: is_config_file "vite.config.ts" && echo "skip TDD"
+is_config_file() {
+  local filepath="$1"
+  local basename
+  basename=$(basename "$filepath")
+
+  case "$filepath" in
+    # Universal config patterns
+    *.config.*|*.setup.*|*.conf|*.cfg) return 0 ;;
+    */migrations/*|*/seeds/*|*/fixtures/*|*/scripts/*|*/bin/*) return 0 ;;
+    */docs/*|*/documentation/*) return 0 ;;
+    *Dockerfile*|*docker-compose*|*.dockerignore) return 0 ;;
+    *Makefile|*.mk) return 0 ;;
+    # Non-code files
+    *.md|*.txt|*.rst|*.json|*.yaml|*.yml|*.toml|*.env*) return 0 ;;
+    *.css|*.scss|*.less|*.html|*.xml|*.svg) return 0 ;;
+  esac
+
+  case "$basename" in
+    # Node.js / TypeScript
+    vite.config*|next.config*|tailwind.config*|postcss.config*) return 0 ;;
+    tsconfig*|biome.json*|eslint.config*|.eslintrc*|.prettierrc*) return 0 ;;
+    package.json|pnpm-lock.yaml|yarn.lock|package-lock.json) return 0 ;;
+    # Python
+    conftest.py|setup.py|setup.cfg|pyproject.toml|manage.py) return 0 ;;
+    wsgi.py|asgi.py|alembic.ini|noxfile.py|tox.ini) return 0 ;;
+    # Rust
+    Cargo.toml|Cargo.lock|build.rs|clippy.toml|rustfmt.toml) return 0 ;;
+    # Go
+    go.mod|go.sum) return 0 ;;
+    # Ruby
+    Gemfile|Gemfile.lock|Rakefile|.rubocop.yml) return 0 ;;
+    # Java / Kotlin / Scala
+    build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts|pom.xml) return 0 ;;
+    build.sbt) return 0 ;;
+    # Elixir
+    mix.exs|mix.lock) return 0 ;;
+    # C / C++
+    CMakeLists.txt|*.cmake) return 0 ;;
+    # Dart
+    pubspec.yaml|pubspec.lock|analysis_options.yaml) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Returns 0 if the file is a language entry point (main, index, app, __init__).
+# Usage: is_entry_point "src/index.ts" && echo "skip TDD"
+is_entry_point() {
+  local basename
+  basename=$(basename "$1")
+
+  case "$basename" in
+    # Node.js / TypeScript
+    index.ts|index.tsx|index.js|index.jsx) return 0 ;;
+    main.ts|main.tsx|main.js|main.jsx) return 0 ;;
+    app.ts|app.tsx|app.js|app.jsx) return 0 ;;
+    # Python
+    __init__.py|__main__.py) return 0 ;;
+    # Rust
+    main.rs|lib.rs|mod.rs) return 0 ;;
+    # Go
+    main.go) return 0 ;;
+    # Java / Kotlin
+    Main.java|Application.java|App.java) return 0 ;;
+    Main.kt|Application.kt|App.kt) return 0 ;;
+    # Elixir
+    application.ex) return 0 ;;
+    # Dart
+    main.dart) return 0 ;;
+    # C / C++
+    main.c|main.cpp|main.cc) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ─── PROJECT DETECTION ─────────────────────────────────────────────────
+
+# Detects all languages present in a project directory.
+# Sets: PROJECT_LANGS (array), PRIMARY_LANG (string)
+# Usage: detect_project_langs "/path/to/project"
+detect_project_langs() {
+  local dir="$1"
+  PROJECT_LANGS=()
+  PRIMARY_LANG=""
+
+  # TypeScript (check before JS — TS projects also have package.json)
+  [ -f "$dir/tsconfig.json" ] && PROJECT_LANGS+=("typescript")
+
+  # JavaScript / Node.js (only if not already detected as TypeScript)
+  if [ -f "$dir/package.json" ] && [[ ! " ${PROJECT_LANGS[*]:-} " =~ " typescript " ]]; then
+    PROJECT_LANGS+=("javascript")
+  fi
+
+  # Deno (separate from Node.js)
+  [ -f "$dir/deno.json" ] || [ -f "$dir/deno.jsonc" ] && PROJECT_LANGS+=("deno")
+
+  # Go
+  [ -f "$dir/go.mod" ] && PROJECT_LANGS+=("go")
+
+  # Rust
+  [ -f "$dir/Cargo.toml" ] && PROJECT_LANGS+=("rust")
+
+  # Python
+  if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/setup.py" ] || \
+     [ -f "$dir/setup.cfg" ] || [ -f "$dir/requirements.txt" ] || \
+     [ -f "$dir/Pipfile" ]; then
+    PROJECT_LANGS+=("python")
+  fi
+
+  # Ruby
+  [ -f "$dir/Gemfile" ] && PROJECT_LANGS+=("ruby")
+
+  # Java
+  if [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ] || \
+     [ -f "$dir/pom.xml" ]; then
+    PROJECT_LANGS+=("java")
+  fi
+
+  # Kotlin (separate from Java if it has specific Kotlin markers)
+  if [ -f "$dir/build.gradle.kts" ] && [ -d "$dir/src/main/kotlin" ]; then
+    PROJECT_LANGS+=("kotlin")
+  fi
+
+  # Elixir
+  [ -f "$dir/mix.exs" ] && PROJECT_LANGS+=("elixir")
+
+  # Swift
+  [ -f "$dir/Package.swift" ] && PROJECT_LANGS+=("swift")
+
+  # C / C++
+  if [ -f "$dir/CMakeLists.txt" ] || [ -f "$dir/Makefile" ] || \
+     [ -f "$dir/meson.build" ]; then
+    PROJECT_LANGS+=("c_cpp")
+  fi
+
+  # Zig
+  [ -f "$dir/build.zig" ] && PROJECT_LANGS+=("zig")
+
+  # Dart / Flutter
+  [ -f "$dir/pubspec.yaml" ] && PROJECT_LANGS+=("dart")
+
+  # C# / .NET
+  if ls "$dir"/*.csproj 1>/dev/null 2>&1 || ls "$dir"/*.sln 1>/dev/null 2>&1; then
+    PROJECT_LANGS+=("csharp")
+  fi
+
+  # Scala
+  [ -f "$dir/build.sbt" ] && PROJECT_LANGS+=("scala")
+
+  # Haskell
+  if [ -f "$dir/stack.yaml" ] || [ -f "$dir/cabal.project" ] || \
+     ls "$dir"/*.cabal 1>/dev/null 2>&1; then
+    PROJECT_LANGS+=("haskell")
+  fi
+
+  # Primary language = first detected
+  if [ ${#PROJECT_LANGS[@]} -gt 0 ]; then
+    PRIMARY_LANG="${PROJECT_LANGS[0]}"
+  fi
+}
+
+# Detects the package manager for Node.js projects.
+# Sets: PKG_MGR (string: pnpm|bun|yarn|npx)
+# Usage: detect_pkg_manager "/path/to/project"
+detect_pkg_manager() {
+  local dir="$1"
+  PKG_MGR=""
+
+  if [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/pnpm-workspace.yaml" ]; then
+    PKG_MGR="pnpm"
+  elif [ -f "$dir/bun.lockb" ] || [ -f "$dir/bun.lock" ]; then
+    PKG_MGR="bun"
+  elif [ -f "$dir/yarn.lock" ]; then
+    PKG_MGR="yarn"
+  elif [ -f "$dir/package-lock.json" ]; then
+    PKG_MGR="npx"
+  elif [ -f "$dir/package.json" ]; then
+    # No lockfile — default to pnpm if available, else npm
+    if command -v pnpm &>/dev/null; then
+      PKG_MGR="pnpm"
+    else
+      PKG_MGR="npx"
+    fi
+  fi
+}
+
+# ─── TEST FILE DETECTION ──────────────────────────────────────────────
+
+# Returns 0 if the file is a test/spec file based on language conventions.
+# Usage: is_test_file "src/foo.test.ts" && echo "this is a test"
+is_test_file() {
+  local filepath="$1"
+  local basename
+  basename=$(basename "$filepath")
+  local ext="${basename##*.}"
+  local lang
+  lang=$(lang_for_extension "$ext")
+
+  case "$lang" in
+    typescript|javascript)
+      case "$basename" in
+        *.test.*|*.spec.*) return 0 ;;
+      esac
+      case "$filepath" in
+        */__tests__/*|*/tests/*|*/test/*) return 0 ;;
+        __tests__/*|tests/*|test/*) return 0 ;;
+      esac
+      ;;
+    python)
+      case "$basename" in
+        test_*|*_test.py) return 0 ;;
+      esac
+      case "$filepath" in
+        */tests/*|*/test/*|tests/*|test/*) return 0 ;;
+      esac
+      ;;
+    go)
+      case "$basename" in
+        *_test.go) return 0 ;;
+      esac
+      ;;
+    rust)
+      # Rust integration tests live in tests/ directory
+      case "$filepath" in
+        tests/*.rs|*/tests/*.rs) return 0 ;;
+        tests/*/*.rs|*/tests/*/*.rs) return 0 ;;
+      esac
+      # Rust unit tests are inline (#[cfg(test)]) — can't detect from filename
+      ;;
+    ruby)
+      case "$basename" in
+        *_spec.rb|*_test.rb|test_*.rb) return 0 ;;
+      esac
+      case "$filepath" in
+        */spec/*|*/test/*|spec/*|test/*) return 0 ;;
+      esac
+      ;;
+    java|kotlin)
+      case "$basename" in
+        *Test.java|*Tests.java|*Spec.java) return 0 ;;
+        *Test.kt|*Tests.kt|*Spec.kt) return 0 ;;
+      esac
+      case "$filepath" in
+        */test/*|*/tests/*|test/*|tests/*) return 0 ;;
+      esac
+      ;;
+    elixir)
+      case "$basename" in
+        *_test.exs) return 0 ;;
+      esac
+      case "$filepath" in
+        */test/*|test/*) return 0 ;;
+      esac
+      ;;
+    swift)
+      case "$basename" in
+        *Tests.swift|*Test.swift) return 0 ;;
+      esac
+      case "$filepath" in
+        */Tests/*|Tests/*) return 0 ;;
+      esac
+      ;;
+    dart)
+      case "$filepath" in
+        */test/*|test/*|*_test.dart) return 0 ;;
+      esac
+      ;;
+    csharp)
+      case "$basename" in
+        *Tests.cs|*Test.cs) return 0 ;;
+      esac
+      case "$filepath" in
+        *.Tests/*|*.Test/*|*/test/*|*/tests/*|test/*|tests/*) return 0 ;;
+      esac
+      ;;
+    c|cpp)
+      case "$filepath" in
+        */test/*|*/tests/*|test/*|tests/*|*_test.c|*_test.cpp) return 0 ;;
+      esac
+      ;;
+    scala)
+      case "$basename" in
+        *Spec.scala|*Test.scala|*Suite.scala) return 0 ;;
+      esac
+      case "$filepath" in
+        */test/*|test/*) return 0 ;;
+      esac
+      ;;
+    zig)
+      # Zig uses inline tests (test "name" { ... }) — can't detect from filename
+      case "$filepath" in
+        */test/*|*/tests/*|test/*|tests/*) return 0 ;;
+      esac
+      ;;
+    haskell)
+      case "$basename" in
+        *Spec.hs|*Test.hs) return 0 ;;
+      esac
+      case "$filepath" in
+        */test/*|*/tests/*|test/*|tests/*) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+# Finds possible test file locations for a source file.
+# Sets: TEST_CANDIDATES (array of absolute paths)
+# Usage: find_test_candidates "/project/src/foo.ts" "/project"
+find_test_candidates() {
+  local filepath="$1"
+  local project_dir="$2"
+  local dirname
+  dirname=$(dirname "$filepath")
+  local basename
+  basename=$(basename "$filepath")
+  local filename="${basename%.*}"
+  local ext="${basename##*.}"
+  local lang
+  lang=$(lang_for_extension "$ext")
+  local rel_path="${filepath#$project_dir/}"
+  local rel_dir
+  rel_dir=$(dirname "$rel_path")
+
+  TEST_CANDIDATES=()
+
+  case "$lang" in
+    typescript|javascript)
+      # Same directory: foo.test.ts, foo.spec.ts
+      TEST_CANDIDATES+=(
+        "$dirname/${filename}.test.${ext}"
+        "$dirname/${filename}.spec.${ext}"
+      )
+      # Cross-extension: .ts file might have .tsx test and vice versa
+      if [ "$ext" = "tsx" ] || [ "$ext" = "ts" ]; then
+        TEST_CANDIDATES+=(
+          "$dirname/${filename}.test.ts"
+          "$dirname/${filename}.test.tsx"
+          "$dirname/${filename}.spec.ts"
+          "$dirname/${filename}.spec.tsx"
+        )
+      fi
+      # __tests__ directory (same level and parent)
+      TEST_CANDIDATES+=(
+        "$dirname/__tests__/${filename}.test.${ext}"
+        "$dirname/__tests__/${filename}.spec.${ext}"
+        "$(dirname "$dirname")/__tests__/${filename}.test.${ext}"
+        "$(dirname "$dirname")/__tests__/${filename}.spec.${ext}"
+      )
+      # Project-level tests/ directory
+      TEST_CANDIDATES+=(
+        "$project_dir/tests/${rel_dir}/${filename}.test.${ext}"
+        "$project_dir/test/${rel_dir}/${filename}.test.${ext}"
+      )
+      ;;
+    python)
+      # Same directory: test_foo.py, foo_test.py
+      TEST_CANDIDATES+=(
+        "$dirname/test_${filename}.py"
+        "$dirname/${filename}_test.py"
+      )
+      # Project-level tests/ directory
+      TEST_CANDIDATES+=(
+        "$project_dir/tests/test_${filename}.py"
+        "$project_dir/tests/${rel_dir}/test_${filename}.py"
+        "$project_dir/tests/unit/test_${filename}.py"
+        "$project_dir/tests/integration/test_${filename}.py"
+      )
+      ;;
+    go)
+      # Go: test file is always in the same directory, same package
+      TEST_CANDIDATES+=("$dirname/${filename}_test.go")
+      ;;
+    rust)
+      # Rust integration tests in tests/ directory
+      TEST_CANDIDATES+=(
+        "$project_dir/tests/${filename}.rs"
+        "$project_dir/tests/test_${filename}.rs"
+      )
+      # Rust also uses inline tests (#[cfg(test)] mod tests { ... })
+      # For the TDD hook, we check if the source file itself has inline tests
+      # This is handled separately in check-test-exists.sh
+      ;;
+    ruby)
+      # spec/ directory (RSpec convention)
+      TEST_CANDIDATES+=(
+        "$dirname/${filename}_spec.rb"
+        "$project_dir/spec/${rel_dir}/${filename}_spec.rb"
+        "$project_dir/spec/unit/${filename}_spec.rb"
+      )
+      # test/ directory (Minitest convention)
+      TEST_CANDIDATES+=(
+        "$dirname/${filename}_test.rb"
+        "$dirname/test_${filename}.rb"
+        "$project_dir/test/${rel_dir}/${filename}_test.rb"
+        "$project_dir/test/${rel_dir}/test_${filename}.rb"
+      )
+      ;;
+    java)
+      # Maven/Gradle convention: src/test/java mirrors src/main/java
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/src/main/java/|/src/test/java/|' | sed "s|${filename}.java|${filename}Test.java|")
+      TEST_CANDIDATES+=("$test_path")
+      test_path=$(echo "$filepath" | sed 's|/src/main/java/|/src/test/java/|' | sed "s|${filename}.java|${filename}Tests.java|")
+      TEST_CANDIDATES+=("$test_path")
+      # Same directory fallback
+      TEST_CANDIDATES+=("$dirname/${filename}Test.java")
+      ;;
+    kotlin)
+      # Same as Java convention
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/src/main/kotlin/|/src/test/kotlin/|' | sed "s|${filename}.kt|${filename}Test.kt|")
+      TEST_CANDIDATES+=("$test_path")
+      TEST_CANDIDATES+=("$dirname/${filename}Test.kt")
+      ;;
+    elixir)
+      # Elixir: test/ mirrors lib/
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/lib/|/test/|' | sed "s|${filename}.ex|${filename}_test.exs|")
+      TEST_CANDIDATES+=("$test_path")
+      TEST_CANDIDATES+=("$project_dir/test/${filename}_test.exs")
+      ;;
+    swift)
+      # Swift Package Manager: Tests/ mirrors Sources/
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/Sources/|/Tests/|' | sed "s|${filename}.swift|${filename}Tests.swift|")
+      TEST_CANDIDATES+=("$test_path")
+      TEST_CANDIDATES+=("$dirname/${filename}Tests.swift")
+      ;;
+    dart)
+      # Dart: test/ mirrors lib/
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/lib/|/test/|' | sed "s|${filename}.dart|${filename}_test.dart|")
+      TEST_CANDIDATES+=("$test_path")
+      TEST_CANDIDATES+=("$project_dir/test/${filename}_test.dart")
+      ;;
+    csharp)
+      # .NET: *.Tests project mirrors source project
+      TEST_CANDIDATES+=(
+        "$dirname/${filename}Tests.cs"
+        "$dirname/${filename}Test.cs"
+      )
+      # Separate test project (ProjectName.Tests/)
+      local proj_name
+      proj_name=$(basename "$(dirname "$dirname")")
+      TEST_CANDIDATES+=(
+        "$project_dir/${proj_name}.Tests/${filename}Tests.cs"
+        "$project_dir/tests/${filename}Tests.cs"
+      )
+      ;;
+    c|cpp)
+      # Common C/C++ test patterns
+      TEST_CANDIDATES+=(
+        "$dirname/${filename}_test.${ext}"
+        "$project_dir/test/${filename}_test.${ext}"
+        "$project_dir/tests/${filename}_test.${ext}"
+        "$project_dir/test/test_${filename}.${ext}"
+        "$project_dir/tests/test_${filename}.${ext}"
+      )
+      ;;
+    scala)
+      # Scala: src/test/scala mirrors src/main/scala
+      local test_path
+      test_path=$(echo "$filepath" | sed 's|/src/main/scala/|/src/test/scala/|' | sed "s|${filename}.scala|${filename}Spec.scala|")
+      TEST_CANDIDATES+=("$test_path")
+      test_path=$(echo "$filepath" | sed 's|/src/main/scala/|/src/test/scala/|' | sed "s|${filename}.scala|${filename}Test.scala|")
+      TEST_CANDIDATES+=("$test_path")
+      ;;
+    haskell)
+      TEST_CANDIDATES+=(
+        "$project_dir/test/${filename}Spec.hs"
+        "$project_dir/test/${filename}Test.hs"
+        "$project_dir/tests/${filename}Spec.hs"
+      )
+      ;;
+  esac
+}
+
+# Returns 0 if the project has test infrastructure set up for the given language.
+# Usage: has_test_infra "/project" "python" && echo "tests configured"
+has_test_infra() {
+  local dir="$1"
+  local lang="${2:-}"
+
+  # If no language specified, check all
+  case "$lang" in
+    typescript|javascript|"")
+      # Node.js test frameworks
+      for marker in "$dir/jest.config"* "$dir/vitest.config"* "$dir/cypress.config"*; do
+        [ -f "$marker" ] 2>/dev/null && return 0
+      done
+      if [ -f "$dir/package.json" ] && command -v jq &>/dev/null; then
+        if jq -e '.scripts.test // .devDependencies.jest // .devDependencies.vitest // .devDependencies.mocha' "$dir/package.json" &>/dev/null; then
+          return 0
+        fi
+      elif [ -f "$dir/package.json" ] && grep -q '"test"' "$dir/package.json" 2>/dev/null; then
+        return 0
+      fi
+      [ -n "$lang" ] && return 1
+      ;;&
+    python|"")
+      [ -f "$dir/pytest.ini" ] && return 0
+      [ -f "$dir/setup.cfg" ] && grep -q '\[tool:pytest\]' "$dir/setup.cfg" 2>/dev/null && return 0
+      [ -f "$dir/pyproject.toml" ] && grep -q '\[tool.pytest' "$dir/pyproject.toml" 2>/dev/null && return 0
+      [ -f "$dir/tox.ini" ] && return 0
+      [ -d "$dir/tests" ] && ls "$dir/tests"/test_*.py 1>/dev/null 2>&1 && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    go|"")
+      [ -f "$dir/go.mod" ] && return 0  # Go has built-in testing
+      [ -n "$lang" ] && return 1
+      ;;&
+    rust|"")
+      [ -f "$dir/Cargo.toml" ] && return 0  # Rust has built-in testing
+      [ -n "$lang" ] && return 1
+      ;;&
+    ruby|"")
+      [ -f "$dir/Gemfile" ] && grep -qE 'rspec|minitest|test-unit' "$dir/Gemfile" 2>/dev/null && return 0
+      [ -d "$dir/spec" ] && return 0
+      [ -d "$dir/test" ] && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    java|kotlin|"")
+      if [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ]; then
+        return 0  # Gradle projects have built-in test support
+      fi
+      [ -f "$dir/pom.xml" ] && return 0  # Maven projects have built-in test support
+      [ -n "$lang" ] && return 1
+      ;;&
+    elixir|"")
+      [ -f "$dir/mix.exs" ] && return 0  # Elixir has built-in testing
+      [ -n "$lang" ] && return 1
+      ;;&
+    swift|"")
+      [ -f "$dir/Package.swift" ] && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    dart|"")
+      [ -f "$dir/pubspec.yaml" ] && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    csharp|"")
+      ls "$dir"/*.Tests.csproj 1>/dev/null 2>&1 && return 0
+      ls "$dir"/tests/*.csproj 1>/dev/null 2>&1 && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    scala|"")
+      [ -f "$dir/build.sbt" ] && return 0
+      [ -n "$lang" ] && return 1
+      ;;&
+    haskell|"")
+      if [ -f "$dir/stack.yaml" ] || ls "$dir"/*.cabal 1>/dev/null 2>&1; then
+        return 0
+      fi
+      [ -n "$lang" ] && return 1
+      ;;&
+    c|cpp|c_cpp|"")
+      [ -f "$dir/CMakeLists.txt" ] && grep -qi 'enable_testing\|add_test\|gtest\|catch2' "$dir/CMakeLists.txt" 2>/dev/null && return 0
+      [ -n "$lang" ] && return 1
+      ;;
+  esac
+
+  return 1
+}
+
+# ─── FORMATTER / LINTER DETECTION ─────────────────────────────────────
+
+# Detects the formatter command for a given file.
+# Sets: FORMATTER_CMD (string, empty if no formatter found)
+# Usage: detect_formatter "/project/src/foo.py" "/project"
+detect_formatter() {
+  local filepath="$1"
+  local project_dir="$2"
+  local ext="${filepath##*.}"
+  local lang
+  lang=$(lang_for_extension "$ext")
+  FORMATTER_CMD=""
+
+  case "$lang" in
+    typescript|javascript)
+      # Detect Node.js package manager first
+      detect_pkg_manager "$project_dir"
+      local runner="${PKG_MGR:-npx}"
+
+      if [ -f "$project_dir/biome.json" ] || [ -f "$project_dir/biome.jsonc" ]; then
+        FORMATTER_CMD="$runner biome check --write"
+      else
+        local has_eslint=false
+        for f in "$project_dir"/eslint.config.* "$project_dir"/.eslintrc.*; do
+          [ -f "$f" ] && has_eslint=true && break
+        done
+        if [ "$has_eslint" = true ]; then
+          FORMATTER_CMD="$runner eslint --fix"
+        fi
+        # Prettier as standalone or alongside ESLint
+        if [ -f "$project_dir/.prettierrc" ] || [ -f "$project_dir/.prettierrc.json" ] || \
+           [ -f "$project_dir/prettier.config.js" ] || [ -f "$project_dir/prettier.config.mjs" ]; then
+          if [ -n "$FORMATTER_CMD" ]; then
+            FORMATTER_CMD="$FORMATTER_CMD \"\$FILE\" && $runner prettier --write"
+          else
+            FORMATTER_CMD="$runner prettier --write"
+          fi
+        fi
+      fi
+      ;;
+    python)
+      # Ruff (fastest, modern) > Black > autopep8 > yapf
+      if command -v ruff &>/dev/null; then
+        FORMATTER_CMD="ruff format"
+        # Also run ruff check --fix for import sorting + lint fixes
+        FORMATTER_CMD="ruff check --fix \"\$FILE\" && ruff format"
+      elif command -v black &>/dev/null; then
+        FORMATTER_CMD="black"
+        # Add isort if available
+        if command -v isort &>/dev/null; then
+          FORMATTER_CMD="isort \"\$FILE\" && black"
+        fi
+      elif command -v autopep8 &>/dev/null; then
+        FORMATTER_CMD="autopep8 --in-place"
+      fi
+      # Check pyproject.toml for tool configs
+      if [ -z "$FORMATTER_CMD" ] && [ -f "$project_dir/pyproject.toml" ]; then
+        if grep -q '\[tool.ruff\]' "$project_dir/pyproject.toml" 2>/dev/null; then
+          FORMATTER_CMD="ruff check --fix \"\$FILE\" && ruff format"
+        elif grep -q '\[tool.black\]' "$project_dir/pyproject.toml" 2>/dev/null; then
+          FORMATTER_CMD="black"
+        fi
+      fi
+      ;;
+    go)
+      # goimports > gofmt (goimports is a superset)
+      if command -v goimports &>/dev/null; then
+        FORMATTER_CMD="goimports -w"
+      elif command -v gofmt &>/dev/null; then
+        FORMATTER_CMD="gofmt -w"
+      fi
+      ;;
+    rust)
+      if command -v rustfmt &>/dev/null || command -v cargo &>/dev/null; then
+        FORMATTER_CMD="rustfmt"
+      fi
+      ;;
+    ruby)
+      if command -v rubocop &>/dev/null; then
+        FORMATTER_CMD="rubocop --autocorrect"
+      elif [ -f "$project_dir/Gemfile" ] && grep -q 'rubocop' "$project_dir/Gemfile" 2>/dev/null; then
+        FORMATTER_CMD="bundle exec rubocop --autocorrect"
+      fi
+      ;;
+    java)
+      if command -v google-java-format &>/dev/null; then
+        FORMATTER_CMD="google-java-format --replace"
+      fi
+      # Gradle spotless
+      if [ -f "$project_dir/build.gradle" ] && grep -q 'spotless' "$project_dir/build.gradle" 2>/dev/null; then
+        FORMATTER_CMD="cd '$project_dir' && ./gradlew spotlessApply"
+      fi
+      ;;
+    kotlin)
+      if command -v ktlint &>/dev/null; then
+        FORMATTER_CMD="ktlint --format"
+      fi
+      ;;
+    elixir)
+      if command -v mix &>/dev/null; then
+        FORMATTER_CMD="mix format"
+      fi
+      ;;
+    swift)
+      if command -v swift-format &>/dev/null; then
+        FORMATTER_CMD="swift-format --in-place"
+      elif command -v swiftformat &>/dev/null; then
+        FORMATTER_CMD="swiftformat"
+      fi
+      ;;
+    dart)
+      if command -v dart &>/dev/null; then
+        FORMATTER_CMD="dart format"
+      fi
+      ;;
+    csharp)
+      if command -v dotnet &>/dev/null; then
+        FORMATTER_CMD="dotnet format"
+      fi
+      ;;
+    c|cpp)
+      if command -v clang-format &>/dev/null; then
+        FORMATTER_CMD="clang-format -i"
+      fi
+      ;;
+    scala)
+      if command -v scalafmt &>/dev/null; then
+        FORMATTER_CMD="scalafmt"
+      fi
+      ;;
+    zig)
+      if command -v zig &>/dev/null; then
+        FORMATTER_CMD="zig fmt"
+      fi
+      ;;
+    haskell)
+      if command -v ormolu &>/dev/null; then
+        FORMATTER_CMD="ormolu --mode inplace"
+      elif command -v fourmolu &>/dev/null; then
+        FORMATTER_CMD="fourmolu --mode inplace"
+      fi
+      ;;
+    lua)
+      if command -v stylua &>/dev/null; then
+        FORMATTER_CMD="stylua"
+      fi
+      ;;
+  esac
+}
+
+# ─── TYPE CHECKER DETECTION ───────────────────────────────────────────
+
+# Detects the type checker command for a project.
+# Sets: TYPECHECKER_CMD (string), TYPECHECKER_NAME (string)
+# Can be called per-language or auto-detect.
+# Usage: detect_typechecker "/project" "typescript"
+detect_typechecker() {
+  local project_dir="$1"
+  local lang="${2:-}"
+  TYPECHECKER_CMD=""
+  TYPECHECKER_NAME=""
+
+  # If no language specified, detect primary
+  if [ -z "$lang" ]; then
+    detect_project_langs "$project_dir"
+    lang="$PRIMARY_LANG"
+  fi
+
+  case "$lang" in
+    typescript)
+      # tsgo (native, fastest) > tsc
+      # tsgo detection is complex — handled inline by end-of-turn-typecheck.sh
+      # This just returns the basic command
+      detect_pkg_manager "$project_dir"
+      local runner="${PKG_MGR:-npx}"
+      if command -v tsgo &>/dev/null; then
+        TYPECHECKER_NAME="tsgo"
+        TYPECHECKER_CMD="tsgo"
+      else
+        TYPECHECKER_NAME="tsc"
+        TYPECHECKER_CMD="$runner tsc --noEmit --skipLibCheck"
+      fi
+      ;;
+    python)
+      # mypy or pyright
+      if command -v pyright &>/dev/null; then
+        TYPECHECKER_NAME="pyright"
+        TYPECHECKER_CMD="pyright"
+      elif command -v mypy &>/dev/null; then
+        TYPECHECKER_NAME="mypy"
+        TYPECHECKER_CMD="mypy ."
+      fi
+      # Check pyproject.toml for config
+      if [ -z "$TYPECHECKER_CMD" ] && [ -f "$project_dir/pyproject.toml" ]; then
+        if grep -q '\[tool.pyright\]' "$project_dir/pyproject.toml" 2>/dev/null; then
+          TYPECHECKER_NAME="pyright (configured)"
+          TYPECHECKER_CMD="pyright"
+        elif grep -q '\[tool.mypy\]' "$project_dir/pyproject.toml" 2>/dev/null; then
+          TYPECHECKER_NAME="mypy (configured)"
+          TYPECHECKER_CMD="mypy ."
+        fi
+      fi
+      ;;
+    go)
+      if command -v go &>/dev/null; then
+        TYPECHECKER_NAME="go vet"
+        TYPECHECKER_CMD="go vet ./..."
+      fi
+      ;;
+    rust)
+      if command -v cargo &>/dev/null; then
+        TYPECHECKER_NAME="cargo check"
+        TYPECHECKER_CMD="cargo check 2>&1"
+      fi
+      ;;
+    java)
+      if [ -f "$project_dir/build.gradle" ] || [ -f "$project_dir/build.gradle.kts" ]; then
+        TYPECHECKER_NAME="gradle compileJava"
+        TYPECHECKER_CMD="cd '$project_dir' && ./gradlew compileJava"
+      elif [ -f "$project_dir/pom.xml" ]; then
+        TYPECHECKER_NAME="mvn compile"
+        TYPECHECKER_CMD="cd '$project_dir' && mvn compile -q"
+      fi
+      ;;
+    kotlin)
+      if [ -f "$project_dir/build.gradle.kts" ]; then
+        TYPECHECKER_NAME="gradle compileKotlin"
+        TYPECHECKER_CMD="cd '$project_dir' && ./gradlew compileKotlin"
+      fi
+      ;;
+    dart)
+      if command -v dart &>/dev/null; then
+        TYPECHECKER_NAME="dart analyze"
+        TYPECHECKER_CMD="dart analyze"
+      fi
+      ;;
+    csharp)
+      if command -v dotnet &>/dev/null; then
+        TYPECHECKER_NAME="dotnet build"
+        TYPECHECKER_CMD="dotnet build --no-restore"
+      fi
+      ;;
+    scala)
+      if [ -f "$project_dir/build.sbt" ]; then
+        TYPECHECKER_NAME="sbt compile"
+        TYPECHECKER_CMD="cd '$project_dir' && sbt compile"
+      fi
+      ;;
+    haskell)
+      if command -v stack &>/dev/null; then
+        TYPECHECKER_NAME="stack build"
+        TYPECHECKER_CMD="stack build --fast --no-run-tests"
+      elif command -v cabal &>/dev/null; then
+        TYPECHECKER_NAME="cabal build"
+        TYPECHECKER_CMD="cabal build"
+      fi
+      ;;
+    swift)
+      if command -v swift &>/dev/null; then
+        TYPECHECKER_NAME="swift build"
+        TYPECHECKER_CMD="swift build"
+      fi
+      ;;
+    zig)
+      if command -v zig &>/dev/null; then
+        TYPECHECKER_NAME="zig build"
+        TYPECHECKER_CMD="zig build"
+      fi
+      ;;
+  esac
+}
+
+# ─── DEPENDENCY MANAGEMENT ────────────────────────────────────────────
+
+# Detects the dependency install command for a project.
+# Sets: DEP_INSTALL_CMD (string), DEP_LANG (string)
+# Usage: detect_dep_install_cmd "/project"
+detect_dep_install_cmd() {
+  local dir="$1"
+  DEP_INSTALL_CMD=""
+  DEP_LANG=""
+
+  detect_project_langs "$dir"
+
+  for lang in "${PROJECT_LANGS[@]}"; do
+    case "$lang" in
+      typescript|javascript)
+        detect_pkg_manager "$dir"
+        DEP_INSTALL_CMD="${PKG_MGR:-npm} install"
+        DEP_LANG="$lang"
+        return 0
+        ;;
+      python)
+        if [ -f "$dir/pyproject.toml" ]; then
+          if grep -q '\[tool.poetry\]' "$dir/pyproject.toml" 2>/dev/null; then
+            DEP_INSTALL_CMD="poetry install"
+          elif command -v uv &>/dev/null; then
+            DEP_INSTALL_CMD="uv sync"
+          elif command -v pip &>/dev/null; then
+            DEP_INSTALL_CMD="pip install -e '.[dev]'"
+          fi
+        elif [ -f "$dir/Pipfile" ]; then
+          DEP_INSTALL_CMD="pipenv install --dev"
+        elif [ -f "$dir/requirements.txt" ]; then
+          DEP_INSTALL_CMD="pip install -r requirements.txt"
+        fi
+        DEP_LANG="python"
+        [ -n "$DEP_INSTALL_CMD" ] && return 0
+        ;;
+      go)
+        DEP_INSTALL_CMD="go mod download"
+        DEP_LANG="go"
+        return 0
+        ;;
+      rust)
+        DEP_INSTALL_CMD="cargo fetch"
+        DEP_LANG="rust"
+        return 0
+        ;;
+      ruby)
+        DEP_INSTALL_CMD="bundle install"
+        DEP_LANG="ruby"
+        return 0
+        ;;
+      java)
+        if [ -f "$dir/gradlew" ]; then
+          DEP_INSTALL_CMD="./gradlew dependencies"
+        elif [ -f "$dir/mvnw" ]; then
+          DEP_INSTALL_CMD="./mvnw dependency:resolve"
+        elif command -v gradle &>/dev/null; then
+          DEP_INSTALL_CMD="gradle dependencies"
+        elif command -v mvn &>/dev/null; then
+          DEP_INSTALL_CMD="mvn dependency:resolve"
+        fi
+        DEP_LANG="java"
+        [ -n "$DEP_INSTALL_CMD" ] && return 0
+        ;;
+      elixir)
+        DEP_INSTALL_CMD="mix deps.get"
+        DEP_LANG="elixir"
+        return 0
+        ;;
+      dart)
+        DEP_INSTALL_CMD="dart pub get"
+        DEP_LANG="dart"
+        return 0
+        ;;
+      csharp)
+        DEP_INSTALL_CMD="dotnet restore"
+        DEP_LANG="csharp"
+        return 0
+        ;;
+      swift)
+        DEP_INSTALL_CMD="swift package resolve"
+        DEP_LANG="swift"
+        return 0
+        ;;
+      haskell)
+        if command -v stack &>/dev/null; then
+          DEP_INSTALL_CMD="stack setup"
+        elif command -v cabal &>/dev/null; then
+          DEP_INSTALL_CMD="cabal update"
+        fi
+        DEP_LANG="haskell"
+        [ -n "$DEP_INSTALL_CMD" ] && return 0
+        ;;
+      scala)
+        if [ -f "$dir/build.sbt" ]; then
+          DEP_INSTALL_CMD="sbt update"
+        fi
+        DEP_LANG="scala"
+        [ -n "$DEP_INSTALL_CMD" ] && return 0
+        ;;
+    esac
+  done
+}
+
+# ─── FILE EXTENSION HELPERS ───────────────────────────────────────────
+
+# Returns a find-compatible pattern for recent code changes, given a language.
+# Usage: code_extensions_for_find "typescript" → "-name '*.ts' -o -name '*.tsx'"
+code_extensions_for_lang() {
+  case "$1" in
+    typescript)       echo "-name '*.ts' -o -name '*.tsx'" ;;
+    javascript)       echo "-name '*.js' -o -name '*.jsx' -o -name '*.mjs'" ;;
+    python)           echo "-name '*.py'" ;;
+    go)               echo "-name '*.go'" ;;
+    rust)             echo "-name '*.rs'" ;;
+    ruby)             echo "-name '*.rb'" ;;
+    java)             echo "-name '*.java'" ;;
+    kotlin)           echo "-name '*.kt' -o -name '*.kts'" ;;
+    elixir)           echo "-name '*.ex' -o -name '*.exs'" ;;
+    swift)            echo "-name '*.swift'" ;;
+    c)                echo "-name '*.c' -o -name '*.h'" ;;
+    cpp|c_cpp)        echo "-name '*.cpp' -o -name '*.cc' -o -name '*.hpp' -o -name '*.h'" ;;
+    csharp)           echo "-name '*.cs'" ;;
+    dart)             echo "-name '*.dart'" ;;
+    scala)            echo "-name '*.scala'" ;;
+    zig)              echo "-name '*.zig'" ;;
+    haskell)          echo "-name '*.hs'" ;;
+    lua)              echo "-name '*.lua'" ;;
+    php)              echo "-name '*.php'" ;;
+    *)                echo "" ;;
+  esac
+}

--- a/hooks/post-edit-quality.sh
+++ b/hooks/post-edit-quality.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# PostToolUse(Write|Edit) hook: Auto-format code after edits.
+#
+# Language-universal — auto-detects the file's language and runs the
+# appropriate formatter/linter. Supports all major languages out of the box.
+#
+# To add a new language: update detect_formatter() in lib/detect-project.sh.
+#
+# Exit codes:
+#   0 — formatted successfully (or skipped)
+#   2 — formatter found unfixable errors
+
 # Check for jq — exit silently if missing (auto-formatting is non-critical)
 if ! command -v jq &>/dev/null; then
   exit 0
@@ -17,20 +28,18 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Skip non-TS/JS files
-case "$FILE_PATH" in
-  *.ts|*.tsx|*.js|*.jsx) ;;
-  *) exit 0 ;;
-esac
+# Source shared detection library
+source ~/.claude/hooks/lib/detect-project.sh
 
-# Skip excluded directories (generated/vendor/build output)
-case "$FILE_PATH" in
-  */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/coverage/*) exit 0 ;;
-  */.turbo/*|*/__generated__/*|*/.generated/*|*/generated/*) exit 0 ;;
-  */.cache/*|*/.output/*|*/.nuxt/*|*/.svelte-kit/*|*/.vercel/*) exit 0 ;;
-  */.graphql/*|*/graphql/generated/*|*/.prisma/*|*/prisma/generated/*) exit 0 ;;
-  */.storybook/static/*|*/out/*|*/.parcel-cache/*|*/.turbopack/*) exit 0 ;;
-esac
+# Skip non-code files
+if ! is_code_file "$FILE_PATH"; then
+  exit 0
+fi
+
+# Skip generated/vendor directories
+if is_generated_path "$FILE_PATH"; then
+  exit 0
+fi
 
 # Resolve project directory
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
@@ -45,52 +54,29 @@ if [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Detect package manager (don't hardcode pnpm — respect the project's choice)
-PKG_MGR="pnpm"
-if [ -f "$PROJECT_DIR/bun.lockb" ] || [ -f "$PROJECT_DIR/bun.lock" ]; then
-  PKG_MGR="bun"
-elif [ -f "$PROJECT_DIR/yarn.lock" ]; then
-  PKG_MGR="yarn"
-elif [ -f "$PROJECT_DIR/package-lock.json" ]; then
-  PKG_MGR="npx"
-fi
+# Detect formatter for this file
+detect_formatter "$FILE_PATH" "$PROJECT_DIR"
 
-# Detect Biome
-if [ -f "$PROJECT_DIR/biome.json" ] || [ -f "$PROJECT_DIR/biome.jsonc" ]; then
-  # Run Biome check with auto-fix
-  OUTPUT=$(cd "$PROJECT_DIR" && $PKG_MGR biome check --write "$FILE_PATH" 2>&1) || {
-    EXIT_CODE=$?
-    # Send first 10 lines of error to stderr
-    echo "$OUTPUT" | head -n 10 >&2
-    exit 2
-  }
+if [ -z "$FORMATTER_CMD" ]; then
   exit 0
 fi
 
-# Detect ESLint
-HAS_ESLINT=false
-for f in "$PROJECT_DIR"/eslint.config.* "$PROJECT_DIR"/.eslintrc.*; do
-  if [ -f "$f" ]; then
-    HAS_ESLINT=true
-    break
-  fi
-done
-
-if [ "$HAS_ESLINT" = true ]; then
-  # Run ESLint with fix
-  OUTPUT=$(cd "$PROJECT_DIR" && $PKG_MGR eslint --fix "$FILE_PATH" 2>&1) || {
+# Run the formatter
+# The FORMATTER_CMD may contain $FILE as a placeholder; if not, append the file path
+if [[ "$FORMATTER_CMD" == *'$FILE'* ]]; then
+  FILE="$FILE_PATH"
+  export FILE
+  OUTPUT=$(cd "$PROJECT_DIR" && eval "$FORMATTER_CMD" 2>&1) || {
     EXIT_CODE=$?
     echo "$OUTPUT" | head -n 10 >&2
     exit 2
   }
-  # Run Prettier
-  OUTPUT=$(cd "$PROJECT_DIR" && $PKG_MGR prettier --write "$FILE_PATH" 2>&1) || {
+else
+  OUTPUT=$(cd "$PROJECT_DIR" && eval "$FORMATTER_CMD" '"$FILE_PATH"' 2>&1) || {
     EXIT_CODE=$?
     echo "$OUTPUT" | head -n 10 >&2
     exit 2
   }
-  exit 0
 fi
 
-# No linter found — skip silently
 exit 0

--- a/hooks/proot-preflight.sh
+++ b/hooks/proot-preflight.sh
@@ -36,29 +36,40 @@ if [ -n "$DISK_FREE_KB" ] && [ "$DISK_FREE_KB" -lt 1048576 ]; then  # < 1GB
   WARNINGS="${WARNINGS}\n⚠ LOW DISK: Only ${DISK_FREE_MB}MB free. Builds may fail."
 fi
 
-# Check for broken symlinks in node_modules
-if [ -d "$PROJECT_DIR/node_modules/.bin" ]; then
-  BROKEN_COUNT=$(find "$PROJECT_DIR/node_modules/.bin" -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l)
-  if [ "$BROKEN_COUNT" -gt 0 ]; then
-    WARNINGS="${WARNINGS}\n⚠ BROKEN SYMLINKS: $BROKEN_COUNT broken symlinks in node_modules/.bin. Run: pnpm install"
+# Node.js-specific checks (only if this is a Node.js project)
+if [ -f "$PROJECT_DIR/package.json" ]; then
+  # Check for broken symlinks in node_modules
+  if [ -d "$PROJECT_DIR/node_modules/.bin" ]; then
+    BROKEN_COUNT=$(find "$PROJECT_DIR/node_modules/.bin" -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l)
+    if [ "$BROKEN_COUNT" -gt 0 ]; then
+      WARNINGS="${WARNINGS}\n⚠ BROKEN SYMLINKS: $BROKEN_COUNT broken symlinks in node_modules/.bin. Run: pnpm install"
+    fi
+  fi
+
+  # Check for .npmrc with node-linker
+  if [ -f "$PROJECT_DIR/.npmrc" ]; then
+    if ! grep -q "node-linker" "$PROJECT_DIR/.npmrc" 2>/dev/null; then
+      WARNINGS="${WARNINGS}\nℹ NPMRC: No node-linker setting. Consider adding node-linker=hoisted to .npmrc for proot compatibility."
+    fi
+  fi
+
+  # Check NODE_OPTIONS
+  if [ -z "${NODE_OPTIONS:-}" ]; then
+    WARNINGS="${WARNINGS}\nℹ MEMORY: NODE_OPTIONS not set. Consider: export NODE_OPTIONS='--max-old-space-size=2048'"
   fi
 fi
 
-# Check for stale SST locks
+# Rust-specific checks
+if [ -f "$PROJECT_DIR/Cargo.toml" ]; then
+  # Rust cross-compilation can be tricky in proot
+  if [ ! -f "$HOME/.cargo/config.toml" ] 2>/dev/null; then
+    WARNINGS="${WARNINGS}\nℹ RUST: No ~/.cargo/config.toml found. Build times may be slow without incremental compilation settings."
+  fi
+fi
+
+# Check for stale SST locks (project-agnostic — SST works with multiple languages)
 if [ -f "$PROJECT_DIR/.sst/lock" ]; then
   WARNINGS="${WARNINGS}\n⚠ SST LOCK: Stale lock file found at .sst/lock. Remove if no deploy is running."
-fi
-
-# Check for .npmrc with node-linker
-if [ -f "$PROJECT_DIR/.npmrc" ]; then
-  if ! grep -q "node-linker" "$PROJECT_DIR/.npmrc" 2>/dev/null; then
-    WARNINGS="${WARNINGS}\nℹ NPMRC: No node-linker setting. Consider adding node-linker=hoisted to .npmrc for proot compatibility."
-  fi
-fi
-
-# Check NODE_OPTIONS
-if [ -z "${NODE_OPTIONS:-}" ]; then
-  WARNINGS="${WARNINGS}\nℹ MEMORY: NODE_OPTIONS not set. Consider: export NODE_OPTIONS='--max-old-space-size=2048'"
 fi
 
 # Only output if there are warnings

--- a/hooks/worktree-preflight.sh
+++ b/hooks/worktree-preflight.sh
@@ -2,12 +2,17 @@
 # Worktree Preflight — validates git and environment readiness for parallel sprint execution.
 # Called by orchestrator Step 0. Can also be sourced manually: source ~/.claude/hooks/worktree-preflight.sh
 #
+# Language-universal — auto-detects project type and manages dependencies accordingly.
+#
 # Exit codes:
 #   0 — ready for worktree execution
 #   1 — fatal error (cannot proceed)
 #   2 — git was bootstrapped (new repo initialized)
 
 set -euo pipefail
+
+# Source shared detection library
+source ~/.claude/hooks/lib/detect-project.sh
 
 PREFLIGHT_LOG=""
 log() { PREFLIGHT_LOG="${PREFLIGHT_LOG}$1\n"; echo "$1"; }
@@ -21,20 +26,198 @@ else
   log "git: no repo found — bootstrapping"
 
   git init
+
   if [ ! -f .gitignore ]; then
+    # Detect project languages for gitignore
+    detect_project_langs "$(pwd)"
+
+    # Start with universal entries
     cat > .gitignore << 'GITIGNORE'
-node_modules/
-.next/
-dist/
-build/
-.turbo/
-.sst/
+# Environment & secrets
 .env
 .env.local
-*.log
+.env.*.local
+
+# OS
 .DS_Store
+Thumbs.db
+*.log
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
 GITIGNORE
-    log "git: created .gitignore"
+
+    # Append language-specific entries
+    for lang in "${PROJECT_LANGS[@]}"; do
+      case "$lang" in
+        typescript|javascript)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Node.js
+node_modules/
+dist/
+build/
+.next/
+.turbo/
+.sst/
+coverage/
+.cache/
+.output/
+.nuxt/
+.vercel/
+GITIGNORE
+          ;;
+        python)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.eggs/
+.venv/
+venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.tox/
+.nox/
+htmlcov/
+GITIGNORE
+          ;;
+        go)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Go
+vendor/
+GITIGNORE
+          ;;
+        rust)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Rust
+target/
+Cargo.lock
+GITIGNORE
+          ;;
+        ruby)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Ruby
+vendor/bundle/
+.bundle/
+coverage/
+tmp/
+GITIGNORE
+          ;;
+        java|kotlin)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Java / Kotlin
+build/
+target/
+.gradle/
+*.class
+*.jar
+GITIGNORE
+          ;;
+        elixir)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Elixir
+_build/
+deps/
+.elixir_ls/
+GITIGNORE
+          ;;
+        dart)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Dart / Flutter
+.dart_tool/
+build/
+.packages
+pubspec.lock
+GITIGNORE
+          ;;
+        csharp)
+          cat >> .gitignore << 'GITIGNORE'
+
+# .NET / C#
+bin/
+obj/
+*.user
+*.suo
+GITIGNORE
+          ;;
+        c_cpp)
+          cat >> .gitignore << 'GITIGNORE'
+
+# C / C++
+cmake-build-*/
+*.o
+*.a
+*.so
+*.dylib
+GITIGNORE
+          ;;
+        scala)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Scala
+target/
+.bsp/
+.metals/
+.bloop/
+GITIGNORE
+          ;;
+        haskell)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Haskell
+.stack-work/
+dist-newstyle/
+GITIGNORE
+          ;;
+        zig)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Zig
+zig-cache/
+zig-out/
+GITIGNORE
+          ;;
+        swift)
+          cat >> .gitignore << 'GITIGNORE'
+
+# Swift
+.build/
+.swiftpm/
+Packages/
+GITIGNORE
+          ;;
+      esac
+    done
+
+    # If no languages detected, add common defaults
+    if [ ${#PROJECT_LANGS[@]} -eq 0 ]; then
+      cat >> .gitignore << 'GITIGNORE'
+
+# Common build outputs
+dist/
+build/
+target/
+out/
+vendor/
+GITIGNORE
+    fi
+
+    log "git: created .gitignore (languages: ${PROJECT_LANGS[*]:-none detected})"
   fi
 
   git add -A
@@ -58,11 +241,9 @@ fi
 
 STALE_COUNT=0
 if git worktree list --porcelain >/dev/null 2>&1; then
-  # Count stale worktrees BEFORE pruning, then prune
   STALE_COUNT=$(git worktree prune --dry-run 2>/dev/null | wc -l || echo 0)
   git worktree prune 2>/dev/null
 
-  # Clean orphaned sprint branches (no worktree, not merged)
   git branch --list 'sprint/*' 2>/dev/null | while read -r branch; do
     branch=$(echo "$branch" | tr -d ' *')
     if ! git worktree list --porcelain 2>/dev/null | grep -q "$branch"; then
@@ -77,39 +258,125 @@ log "git: pruned ${STALE_COUNT} stale worktrees"
 PROOT_DETECTED=false
 if uname -r 2>/dev/null | grep -q PRoot-Distro && [ "$(uname -m)" = "aarch64" ]; then
   PROOT_DETECTED=true
-  export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
-  export CHOKIDAR_USEPOLLING=true
-  export WATCHPACK_POLLING=true
-  log "proot: ARM64 detected — env vars set (NODE_OPTIONS, CHOKIDAR, WATCHPACK)"
+  # Node.js-specific env vars (only if Node.js project)
+  detect_project_langs "$(pwd)"
+  for lang in "${PROJECT_LANGS[@]}"; do
+    case "$lang" in
+      typescript|javascript)
+        export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
+        export CHOKIDAR_USEPOLLING=true
+        export WATCHPACK_POLLING=true
+        log "proot: ARM64 detected — Node.js env vars set (NODE_OPTIONS, CHOKIDAR, WATCHPACK)"
+        break
+        ;;
+    esac
+  done
+  if [[ ! " ${PROJECT_LANGS[*]:-} " =~ " typescript " ]] && [[ ! " ${PROJECT_LANGS[*]:-} " =~ " javascript " ]]; then
+    log "proot: ARM64 detected — non-Node.js project, no extra env vars needed"
+  fi
 else
   log "proot: not detected"
 fi
 
-# --- 5. Dependency baseline (Node projects) ---
+# --- 5. Dependency baseline (all languages) ---
 
 DEPS_STATUS="skipped"
-if [ -f package.json ]; then
-  if [ ! -d node_modules ]; then
-    DEPS_STATUS="installed"
-    # Ensure hoisted layout for proot compat
-    if [ "$PROOT_DETECTED" = true ] && ! grep -q 'node-linker=hoisted' .npmrc 2>/dev/null; then
-      echo "node-linker=hoisted" >> .npmrc
-      log "deps: added node-linker=hoisted to .npmrc"
-    fi
-    pnpm install 2>/dev/null || log "deps: pnpm install failed (may need manual intervention)"
-  else
-    BROKEN=$(find node_modules/.bin -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l)
-    if [ "$BROKEN" -gt 0 ]; then
-      DEPS_STATUS="repaired"
-      log "deps: ${BROKEN} broken symlinks — reinstalling"
-      pnpm install 2>/dev/null || true
-    else
-      DEPS_STATUS="ok"
-    fi
-  fi
-  log "deps: ${DEPS_STATUS}"
-else
-  log "deps: no package.json — skipped"
+detect_project_langs "$(pwd)"
+
+for lang in "${PROJECT_LANGS[@]}"; do
+  case "$lang" in
+    typescript|javascript)
+      if [ -f package.json ]; then
+        if [ ! -d node_modules ]; then
+          DEPS_STATUS="installed"
+          detect_pkg_manager "$(pwd)"
+          # Ensure hoisted layout for proot compat
+          if [ "$PROOT_DETECTED" = true ] && ! grep -q 'node-linker=hoisted' .npmrc 2>/dev/null; then
+            echo "node-linker=hoisted" >> .npmrc
+            log "deps: added node-linker=hoisted to .npmrc"
+          fi
+          ${PKG_MGR:-pnpm} install 2>/dev/null || log "deps: ${PKG_MGR:-pnpm} install failed (may need manual intervention)"
+        else
+          BROKEN=$(find node_modules/.bin -type l ! -exec test -e {} \; -print 2>/dev/null | wc -l)
+          if [ "$BROKEN" -gt 0 ]; then
+            DEPS_STATUS="repaired"
+            detect_pkg_manager "$(pwd)"
+            log "deps: ${BROKEN} broken symlinks — reinstalling"
+            ${PKG_MGR:-pnpm} install 2>/dev/null || true
+          else
+            DEPS_STATUS="ok"
+          fi
+        fi
+        log "deps: node.js — ${DEPS_STATUS}"
+      fi
+      ;;
+    python)
+      if [ -f pyproject.toml ] || [ -f requirements.txt ] || [ -f Pipfile ]; then
+        if [ ! -d .venv ] && [ ! -d venv ]; then
+          detect_dep_install_cmd "$(pwd)"
+          if [ -n "$DEP_INSTALL_CMD" ]; then
+            DEPS_STATUS="installed"
+            eval "$DEP_INSTALL_CMD" 2>/dev/null || log "deps: python install failed"
+          fi
+        else
+          DEPS_STATUS="ok"
+        fi
+        log "deps: python — ${DEPS_STATUS}"
+      fi
+      ;;
+    go)
+      if [ -f go.mod ]; then
+        go mod download 2>/dev/null && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+        log "deps: go — ${DEPS_STATUS}"
+      fi
+      ;;
+    rust)
+      if [ -f Cargo.toml ]; then
+        cargo fetch 2>/dev/null && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+        log "deps: rust — ${DEPS_STATUS}"
+      fi
+      ;;
+    ruby)
+      if [ -f Gemfile ]; then
+        if [ ! -d vendor/bundle ] && ! bundle check &>/dev/null; then
+          DEPS_STATUS="installed"
+          bundle install 2>/dev/null || log "deps: bundle install failed"
+        else
+          DEPS_STATUS="ok"
+        fi
+        log "deps: ruby — ${DEPS_STATUS}"
+      fi
+      ;;
+    elixir)
+      if [ -f mix.exs ]; then
+        mix deps.get 2>/dev/null && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+        log "deps: elixir — ${DEPS_STATUS}"
+      fi
+      ;;
+    dart)
+      if [ -f pubspec.yaml ]; then
+        dart pub get 2>/dev/null && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+        log "deps: dart — ${DEPS_STATUS}"
+      fi
+      ;;
+    java)
+      if [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+        DEPS_STATUS="ok"  # Gradle resolves dependencies at build time
+        log "deps: java/gradle — ${DEPS_STATUS}"
+      elif [ -f pom.xml ]; then
+        DEPS_STATUS="ok"  # Maven resolves dependencies at build time
+        log "deps: java/maven — ${DEPS_STATUS}"
+      fi
+      ;;
+    *)
+      # Other languages: just log
+      log "deps: ${lang} — no automated dependency management"
+      ;;
+  esac
+done
+
+if [ "$DEPS_STATUS" = "skipped" ]; then
+  log "deps: no recognized project files — skipped"
 fi
 
 # --- Summary ---
@@ -120,6 +387,7 @@ echo "git_bootstrapped: ${GIT_BOOTSTRAPPED}"
 echo "proot_detected: ${PROOT_DETECTED}"
 echo "deps_status: ${DEPS_STATUS}"
 echo "stale_worktrees_pruned: ${STALE_COUNT}"
+echo "languages_detected: ${PROJECT_LANGS[*]:-none}"
 echo "==================================="
 
 if [ "$GIT_BOOTSTRAPPED" = true ]; then

--- a/workflow/09-hooks-and-enforcement.md
+++ b/workflow/09-hooks-and-enforcement.md
@@ -76,12 +76,12 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 
 | Hook | Type | Trigger | Purpose | Blocking? |
 |---|---|---|---|---|
-| `block-dangerous.sh` | PreToolUse(Bash) | Every shell command | Block destructive operations | Hard/soft block |
-| `proot-preflight.sh` | PreToolUse(Bash) | First command/session | Warn about proot issues | No (informational) |
-| `check-test-exists.sh` | PreToolUse(Write/Edit) | Every file edit | TDD gate — require test file | Yes (exit 2 if missing) |
-| `post-edit-quality.sh` | PostToolUse(Write/Edit) | Every file edit | Auto-format TS/JS | Yes (exit 2 on lint errors) |
+| `block-dangerous.sh` | PreToolUse(Bash) | Every shell command | Block destructive operations; project-aware pkg mgr | Hard/soft block |
+| `proot-preflight.sh` | PreToolUse(Bash) | First command/session | Warn about proot issues (language-aware) | No (informational) |
+| `check-test-exists.sh` | PreToolUse(Write/Edit) | Every file edit | TDD gate — require test file (16 languages) | Yes (exit 2 if missing) |
+| `post-edit-quality.sh` | PostToolUse(Write/Edit) | Every file edit | Auto-format code (all languages) | Yes (exit 2 on lint errors) |
 | `check-invariants.sh` | PostToolUse(Write/Edit) | Every file edit | Verify INVARIANTS.md rules | Yes (exit 2 on violation) |
-| `end-of-turn-typecheck.sh` | Stop | End of turn | Type-check TypeScript | Yes (exit 2 on type errors) |
+| `end-of-turn-typecheck.sh` | Stop | End of turn | Static type checking (all languages) | Yes (exit 2 on type errors) |
 | `compound-reminder.sh` | Stop | End of turn | Ensure /compound ran | Yes (exit 2 if skipped) |
 | `verify-completion.sh` | Stop | End of turn | Block premature completion | Yes (exit 2 without evidence) |
 | `validate-i18n-keys.sh` | (ship-test-ensure) | Pre-commit | Cross-validate i18n keys across locales | No (informational) |
@@ -109,47 +109,50 @@ Runs **before** every Bash command and implements three protection levels:
 |---|---|---|
 | Destructive git | `git push --force`, `git reset --hard`, `git checkout .`, `git restore .`, `git branch -D`, `git clean -f`, `git stash drop/clear` | Can destroy work irreversibly |
 | Push to main | `git push ... main/master` | Enforces PR workflow |
-| Wrong package manager | `npm install/run/exec/start/test/build/ci/init`, `npx` | Project uses pnpm exclusively |
+| Package manager mismatch | `npm`/`npx` (only when `pnpm-lock.yaml` exists) | Project-aware: only blocks npm in pnpm projects |
 
 The hook uses pure bash regex matching (no subprocesses) for performance.
 
 ## PostToolUse: post-edit-quality.sh
 
-Runs **after** every Write, Edit, or MultiEdit operation:
+Runs **after** every Write, Edit, or MultiEdit operation. **Language-universal** — auto-detects the file's language and project's formatter.
 
 ```
 File edited
     │
     ▼
-Is it a TS/JS file? ─── No ──► skip
+Is it a code file? ─── No ──► skip
+(detects via lib/detect-project.sh)
     │
    Yes
     │
     ▼
-Is it in an excluded dir? ─── Yes ──► skip
-(node_modules, dist, .next, etc.)
+Is it in a generated/vendor dir? ─── Yes ──► skip
+(node_modules, target/, __pycache__, .venv, etc.)
     │
    No
     │
     ▼
-Biome config exists? ─── Yes ──► biome check --write
+Detect formatter for this file's language:
+  TS/JS: Biome > ESLint > Prettier
+  Python: ruff > black > autopep8
+  Go: goimports > gofmt
+  Rust: rustfmt
+  Ruby: rubocop
+  Elixir: mix format
+  Dart: dart format
+  C/C++: clang-format
+  (and more — see lib/detect-project.sh)
     │
-   No
-    │
-    ▼
-ESLint config exists? ─── Yes ──► eslint --fix + prettier --write
-    │
-   No
-    │
-    ▼
-skip (no linter found)
+    ├─ Found ──► run formatter
+    └─ Not found ──► skip silently
 ```
 
-**Why this matters:** The agent never needs to remember to format code. Every edit is auto-formatted with zero cognitive overhead.
+**Why this matters:** The agent never needs to remember to format code. Every edit is auto-formatted with zero cognitive overhead, regardless of language.
 
 ## Stop Hook: end-of-turn-typecheck.sh
 
-When the agent tries to end a turn after writing code:
+When the agent tries to end a turn after writing code. **Language-universal** — auto-detects the project's language(s) and runs the appropriate type/static checker.
 
 ```
 Agent wants to stop
@@ -160,22 +163,29 @@ Was code written this turn? ─── No ──► allow stop
    Yes
     │
     ▼
-Has tsconfig.json? ─── No ──► allow stop
+Detect project language(s) ─── None ──► allow stop
     │
-   Yes
+   Found
     │
     ▼
-Find type checker (preference order):
-1. Native tsgo binary (cached path for speed)
-2. Global tsgo
-3. pnpm tsc --noEmit --skipLibCheck (fallback)
+Resolve type checker for detected language:
+  TypeScript: tsgo (native, cached) > tsgo (global) > tsc
+  Python: pyright > mypy
+  Go: go vet
+  Rust: cargo check
+  Java: gradle/maven compile
+  Dart: dart analyze
+  C#: dotnet build
+  (and more — see lib/detect-project.sh)
+    │
+    ├─ No checker found ──► allow stop
     │
     ▼
 Run type checker
     │
     ├─ Pass ──► allow stop
-    ├─ Fail ──► BLOCK (agent must fix types)
-    └─ Crash ──► fallback to tsc
+    ├─ Fail ──► BLOCK (agent must fix errors)
+    └─ Crash (tsgo only) ──► fallback to tsc
 ```
 
 ## Stop Hook: compound-reminder.sh
@@ -223,8 +233,8 @@ Was /compound run?
 | Setting | Purpose |
 |---|---|
 | `ENABLE_LSP_TOOL` | Enables Language Server Protocol (goToDefinition, findReferences, etc.) |
-| `NODE_OPTIONS` | Increases Node.js memory limit (essential for proot-distro ARM64) |
-| `CHOKIDAR_USEPOLLING` / `WATCHPACK_POLLING` | Enables polling-based file watching |
+| `NODE_OPTIONS` | Increases Node.js memory limit (essential for proot-distro ARM64; harmless for non-Node projects) |
+| `CHOKIDAR_USEPOLLING` / `WATCHPACK_POLLING` | Enables polling-based file watching (Node.js only; harmless for others) |
 | `bypassPermissions` | Allows autonomous execution — compensated by hook safety |
 | `effortLevel: "high"` | Claude invests more tokens/reasoning in responses |
 
@@ -254,38 +264,47 @@ Exit codes: `0` = allow, `1` = error, `2` = block with message (stderr).
 
 ## PreToolUse: check-test-exists.sh
 
-Runs **before** every Write, Edit, or MultiEdit on production code files. Enforces TDD — you must write the test file before editing the implementation.
+Runs **before** every Write, Edit, or MultiEdit on production code files. Enforces TDD — you must write the test file before editing the implementation. **Language-universal** — supports 16 languages with idiomatic test patterns.
 
 ```
 File about to be edited
     │
     ▼
-Is it a code file? (.ts/.tsx/.js/.jsx) ─── No ──► allow
+Is it a code file? ─── No ──► allow
+(any of 16 supported languages)
     │
    Yes
     │
     ▼
 Is it skip-listed? ──── Yes ──► allow
-(test files, config files, index.ts,
- types.ts, .d.ts, migrations, etc.)
+(test files, config files, entry points,
+ .d.ts, migrations, generated dirs, etc.)
     │
    No
     │
     ▼
 Does project have test infrastructure? ─── No ──► allow
-(vitest.config, jest.config, etc.)
+(language-aware: vitest, pytest, go.mod,
+ Cargo.toml, rspec, gradle, etc.)
     │
    Yes
     │
     ▼
 Does a matching test file exist? ─── Yes ──► allow
-(__tests__/name.test.ts, name.test.ts,
- name.spec.ts, tests/name.test.ts)
+(language-idiomatic patterns:
+ TS/JS: foo.test.ts, foo.spec.ts, __tests__/
+ Python: test_foo.py, foo_test.py, tests/
+ Go: foo_test.go
+ Rust: tests/foo.rs, inline #[cfg(test)]
+ Ruby: foo_spec.rb, spec/, test/
+ Java: FooTest.java, src/test/java/
+ and more...)
     │
    No
     │
     ▼
 BLOCK (exit 2): "Write the test first"
+  (includes language name and expected test locations)
 ```
 
 **Why this matters:** TDD is mandatory. Without this hook, agents write implementation first and tests as an afterthought — leading to tests that validate output rather than behavior.


### PR DESCRIPTION
## Summary

- Refactored all hooks from TypeScript/Node.js-specific to **language-universal**, supporting 16 languages out of the box
- Created a **shared detection library** (`hooks/lib/detect-project.sh`) that centralizes all language detection — adding a new language means updating **one file**
- Added comprehensive documentation (`docs/universal-workflow-guide.md`) with step-by-step instructions for extending to any language

## What Changed

| Hook | Before | After |
|------|--------|-------|
| `end-of-turn-typecheck.sh` | TypeScript only (tsgo/tsc) | Any language (cargo check, go vet, mypy, pyright, dart analyze, etc.) |
| `post-edit-quality.sh` | TS/JS + Biome/ESLint | Any language × any formatter (ruff, rustfmt, gofmt, clang-format, etc.) |
| `check-test-exists.sh` | TS/JS + Python + Go | 16 languages with idiomatic test patterns |
| `worktree-preflight.sh` | Node.js deps only | Multi-language deps + language-aware .gitignore |
| `block-dangerous.sh` | Always blocked npm/npx | Only blocks npm/npx when pnpm-lock.yaml exists |
| `proot-preflight.sh` | Always checked node_modules | Node.js checks conditional on package.json |
| `check-invariants.sh` | Hardcoded extension list | Uses shared library for detection |

### Supported Languages

TypeScript, JavaScript, Python, Go, Rust, Ruby, Java, Kotlin, Elixir, Swift, Dart, C#, Scala, C/C++, Haskell, Zig

### Backward Compatibility

Existing TS/JS projects work identically — TypeScript detection is prioritized, tsgo optimization is preserved, pnpm enforcement stays active for pnpm projects.

## Architecture

```
hooks/lib/detect-project.sh    ← ALL language detection (1 file)
    ↕ sourced by ↕
hooks/end-of-turn-typecheck.sh
hooks/post-edit-quality.sh
hooks/check-test-exists.sh
hooks/check-invariants.sh
hooks/worktree-preflight.sh
```

## Test Plan

- [x] 443 assertions passing across all hooks and detection functions
- [x] Tested: extension mapping (33 exts), code file detection (14), generated paths (30), config files (33), entry points (20), test files (36), project detection (14), pkg manager (8), test candidates (12), test infra (8)
- [x] Tested: check-test-exists blocks correctly for TS, Go, Rust, Python, Ruby, Java
- [x] Tested: check-test-exists allows with matching test files and inline tests (Rust #[cfg(test)], Zig test blocks)
- [x] Tested: block-dangerous.sh enforces npm/npx only for pnpm projects, allows for all others
- [x] Tested: worktree-preflight generates language-aware .gitignore for Python, Rust, Go, Java, Elixir, Node.js
- [x] Tested: all hooks handle edge cases (empty input, nonexistent files, .d.ts, CSS files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)