### PR TITLE
fix: guard Node.js hooks against missing node_modules

### DIFF
--- a/hooks/end-of-turn-typecheck.sh
+++ b/hooks/end-of-turn-typecheck.sh
@@ -122,6 +122,16 @@ TOOL_NAME=""
 TOOL_CMD=""
 
 for lang in "${PROJECT_LANGS[@]}"; do
+  # Skip languages that need installed dependencies when node_modules is missing
+  case "$lang" in
+    typescript|javascript)
+      if ! has_node_deps_installed "$PROJECT_DIR"; then
+        echo "⚠ Typecheck skipped: node_modules missing or empty. Run pnpm install." >&2
+        exit 0
+      fi
+      ;;
+  esac
+
   case "$lang" in
     typescript)
       # TypeScript has special tsgo optimization

--- a/hooks/lib/detect-project.sh
+++ b/hooks/lib/detect-project.sh
@@ -583,6 +583,10 @@ has_test_infra() {
   # If no language specified, check all
   case "$lang" in
     typescript|javascript|"")
+      # Skip TDD enforcement if deps not installed — can't run tests anyway
+      if [ -n "$lang" ] && ! has_node_deps_installed "$dir"; then
+        return 1
+      fi
       # Node.js test frameworks
       for marker in "$dir/jest.config"* "$dir/vitest.config"* "$dir/cypress.config"*; do
         [ -f "$marker" ] 2>/dev/null && return 0
@@ -676,6 +680,11 @@ detect_formatter() {
 
   case "$lang" in
     typescript|javascript)
+      # Skip if node_modules missing — formatters are installed as deps
+      if ! has_node_deps_installed "$project_dir"; then
+        return 0
+      fi
+
       # Detect Node.js package manager first
       detect_pkg_manager "$project_dir"
       local runner="${PKG_MGR:-npx}"
@@ -1036,6 +1045,16 @@ detect_dep_install_cmd() {
         ;;
     esac
   done
+}
+
+# ─── DEPENDENCY STATE ────────────────────────────────────────────────
+
+# Returns 0 if Node.js dependencies appear to be installed.
+# Checks for a non-empty node_modules directory.
+# Usage: has_node_deps_installed "/project" && echo "deps OK"
+has_node_deps_installed() {
+  local dir="$1"
+  [ -d "$dir/node_modules" ] && [ -n "$(ls -A "$dir/node_modules" 2>/dev/null)" ]
 }
 
 # ─── FILE EXTENSION HELPERS ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added shared `has_node_deps_installed()` function to `lib/detect-project.sh`
- `end-of-turn-typecheck.sh`: skips typecheck with clear warning when node_modules missing
- `detect_formatter()`: skips JS/TS formatting silently (no binary available)
- `has_test_infra()`: skips TDD enforcement (can't run tests without deps)

## Context
Hooks assumed `node_modules` was always present, causing confusing "Cannot find module" errors on new/cloned projects before `pnpm install`.

## Test plan
- [ ] Clone a fresh TS project without running `pnpm install` — hooks should skip gracefully
- [ ] Run `pnpm install` — hooks should resume normal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)