### PR TITLE
feat: interactive soft block approval via AskUserQuestion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,11 +354,22 @@ The "Agent NEVER does" column is enforced as PreToolUse hooks in `~/.claude/sett
 Anti-Goodhart verification is enforced by sprint-executor Step 8, orchestrator Step 8.5, and plan-build-test Phase 5.5 — not by hooks.
 
 - **Hard block** (`permissionDecision: "deny"` — always denied, no user override): `rm -rf /`, `rm -rf` on system directories (`/etc`, `/usr`, `/var`, `/home`, etc.), `dd`, fork bombs
-- **Soft block** (`permissionDecision: "ask"` — prompts user for confirmation):
+- **Soft block** (deny + `SOFT_BLOCK_APPROVAL_NEEDED` prefix — interactive approval):
   - Destructive git: `git push --force`, `git push -f`, `git push --force-with-lease`, `git push ... main/master`, `git reset --hard`, `git checkout .`, `git restore .`, `git branch -D`, `git clean -f`, `git stash drop/clear`
   - Package manager mismatch: `npm`/`npx` blocked only when `pnpm-lock.yaml` exists (project-aware detection)
 
-Hard blocks use `deny()` → user cannot override. Soft blocks use `ask()` → Claude Code prompts the user to approve or reject.
+Hard blocks use `deny()` → user cannot override. Soft blocks use `ask()` → returns deny with `SOFT_BLOCK_APPROVAL_NEEDED` prefix.
+
+### Soft Block Interactive Approval Protocol
+
+When a hook returns a denial with `SOFT_BLOCK_APPROVAL_NEEDED:` prefix, you MUST:
+
+1. **Present the reason** to the user clearly
+2. **Ask the user** to approve or deny using AskUserQuestion with yes/no options
+3. **If user approves:** run `~/.claude/hooks/approve.sh` via Bash, then **retry the original blocked command**
+4. **If user denies:** respect the block, do NOT retry, and adjust your approach
+
+NEVER tell the user to manually run `approve.sh`. NEVER skip the interactive prompt. The approval flow is: hook blocks → you ask → user decides → you act.
 
 ---
 

--- a/hooks/block-dangerous.sh
+++ b/hooks/block-dangerous.sh
@@ -60,7 +60,7 @@ EOJSON
 
 # Helper to soft-block with reason (destructive but legitimate — user can approve)
 # Uses "deny" instead of "ask" because "ask" is silently ignored in bypassPermissions mode.
-# Creates a pending approval file so the user can approve via: ! ~/.claude/hooks/approve.sh
+# Creates a pending approval file so Claude can approve via AskUserQuestion → approve.sh.
 ask() {
   # Create pending approval file
   mkdir -p "$PENDING_DIR" 2>/dev/null || true
@@ -72,7 +72,7 @@ ask() {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "$1 To approve, run:  ! ~/.claude/hooks/approve.sh  — then retry the command."
+    "permissionDecisionReason": "SOFT_BLOCK_APPROVAL_NEEDED: $1"
   }
 }
 EOJSON

--- a/hooks/tests/test-block-dangerous.sh
+++ b/hooks/tests/test-block-dangerous.sh
@@ -193,7 +193,7 @@ run_hook "git push -u origin main"
 assert_exit 0 "soft block exits 0"
 assert_stdout_contains '"permissionDecision"' "soft block outputs JSON to stdout"
 assert_json_field "permissionDecision" "deny" "soft block uses permissionDecision: deny"
-assert_stdout_contains "approve.sh" "soft block includes approval instructions"
+assert_stdout_contains "SOFT_BLOCK_APPROVAL_NEEDED" "soft block includes SOFT_BLOCK_APPROVAL_NEEDED prefix"
 assert_stderr_clean "soft block has no error output on stderr"
 
 section "Output Format — Valid JSON"
@@ -304,7 +304,7 @@ section "Soft Blocks — Destructive Git Commands"
 cleanup
 run_hook "git push --force origin feature"
 assert_stdout_contains '"permissionDecision"' "git push --force is soft-blocked"
-assert_stdout_contains "approve.sh" "git push --force shows approval instructions"
+assert_stdout_contains "SOFT_BLOCK_APPROVAL_NEEDED" "git push --force shows SOFT_BLOCK_APPROVAL_NEEDED prefix"
 
 cleanup
 run_hook "git push -f origin feature"


### PR DESCRIPTION
## Summary

- Replace manual `approve.sh` instructions in soft block deny reasons with `SOFT_BLOCK_APPROVAL_NEEDED:` prefix
- Add "Soft Block Interactive Approval Protocol" to CLAUDE.md instructing Claude to present yes/no prompt via AskUserQuestion and handle approval automatically
- Update test assertions to match new output format

## What changed

**`hooks/block-dangerous.sh`** — The `ask()` function now outputs `SOFT_BLOCK_APPROVAL_NEEDED: <reason>` instead of telling the user to manually run `approve.sh`.

**`CLAUDE.md`** — New "Soft Block Interactive Approval Protocol" section defining the flow: hook blocks → Claude asks user yes/no → if yes, Claude runs approve.sh → retries command.

**`hooks/tests/test-block-dangerous.sh`** — Two assertions updated to check for `SOFT_BLOCK_APPROVAL_NEEDED` prefix instead of `approve.sh` string.

## Test plan

- [x] Hook-specific tests: 97/97 passed
- [x] Workflow integrity tests: 304/304 passed
- [x] Approval token lifecycle still works (create pending → approve → retry → allowed)
- [x] Hard blocks unchanged (still use `deny()` with no override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)