### PR TITLE
fix: approve.sh TTL starts from approval time, not pending creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ evolution/session-postmortems/*.md
 
 # Exclude hook runtime artifacts
 hooks/logs/
+hooks/.approvals/
 
 # Exclude session state markers (preflight, compound, completion evidence)
 state/

--- a/hooks/approve.sh
+++ b/hooks/approve.sh
@@ -22,6 +22,7 @@ for f in "$PENDING_DIR"/*; do
   echo "Approving:"
   cat "$f"
   mv "$f" "$APPROVAL_DIR/$(basename "$f")"
+  touch "$APPROVAL_DIR/$(basename "$f")"  # Reset mtime so TTL starts from approval, not pending creation
   count=$((count + 1))
   echo "---"
 done


### PR DESCRIPTION
## Summary
- Add `touch` after `mv` in `approve.sh` so the 5-minute TTL is measured from when the user approved, not when the soft-block first occurred
- `mv` preserves the original file mtime, causing tokens to expire prematurely when LLM processing time pushes the approve+retry cycle past 5 minutes
- Also gitignore `.approvals/` runtime directory

## Root cause
Discovered while investigating why soft-block approval worked in one project but not another. The hook log showed the retry was 7m41s after the initial block (due to accumulated LLM processing time), exceeding the 300s TTL.