### PR TITLE
feat: add auto-version bump on PR merge

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,87 @@
+name: Auto Version
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore(version):')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No tags found, skipping"
+            echo "bump=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s" --no-merges)
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits since $LATEST_TAG"
+            echo "bump=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BUMP="none"
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
+            if echo "$msg" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$msg" | grep -qi 'BREAKING CHANGE'; then
+              BUMP="major"; break
+            fi
+            if echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
+              [ "$BUMP" != "major" ] && BUMP="minor"
+            fi
+            if echo "$msg" | grep -qE '^(fix|perf)(\(.+\))?:'; then
+              [ "$BUMP" = "none" ] && BUMP="patch"
+            fi
+          done <<< "$COMMITS"
+
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "Determined bump: $BUMP"
+
+      - name: Bump version
+        if: steps.bump.outputs.bump != 'none'
+        id: version
+        env:
+          BUMP: ${{ steps.bump.outputs.bump }}
+        run: |
+          CURRENT=$(cat VERSION)
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "$NEW_VERSION" > VERSION
+
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped $CURRENT → $NEW_VERSION ($BUMP)"
+
+      - name: Commit and tag
+        if: steps.bump.outputs.bump != 'none'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add VERSION
+          git commit -m "chore(version): bump to v${NEW_VERSION}"
+          git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+          git push origin main --follow-tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run hook-specific tests
         run: bash "$HOME/.claude/hooks/tests/test-block-dangerous.sh"
+
+      - name: Run auto-version tests
+        run: bash "$HOME/.claude/tests/test-auto-version.sh"

--- a/tests/test-auto-version.sh
+++ b/tests/test-auto-version.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Tests for auto-version bump logic
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+assert_bump() {
+  local expected="$1"
+  shift
+  local commits="$*"
+
+  local bump="none"
+  while IFS= read -r msg; do
+    [ -z "$msg" ] && continue
+    if echo "$msg" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$msg" | grep -qi 'BREAKING CHANGE'; then
+      bump="major"; break
+    fi
+    if echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
+      [ "$bump" != "major" ] && bump="minor"
+    fi
+    if echo "$msg" | grep -qE '^(fix|perf)(\(.+\))?:'; then
+      [ "$bump" = "none" ] && bump="patch"
+    fi
+  done <<< "$commits"
+
+  if [ "$bump" = "$expected" ]; then
+    echo "  PASS: expected=$expected got=$bump"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: expected=$expected got=$bump | commits: $commits"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_version_bump() {
+  local current="$1"
+  local bump_type="$2"
+  local expected="$3"
+
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$current"
+  case "$bump_type" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+  esac
+  local result="${MAJOR}.${MINOR}.${PATCH}"
+
+  if [ "$result" = "$expected" ]; then
+    echo "  PASS: $current + $bump_type = $result"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $current + $bump_type → expected $expected, got $result"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Commit Message Parsing ==="
+assert_bump "minor" "feat: add new feature"
+assert_bump "minor" "feat(auth): add login"
+assert_bump "patch" "fix: correct bug"
+assert_bump "patch" "fix(ui): button alignment"
+assert_bump "patch" "perf: optimize query"
+assert_bump "patch" "perf(db): index lookup"
+assert_bump "major" "feat!: breaking change"
+assert_bump "major" "fix(auth)!: breaking fix"
+assert_bump "none" "docs: update readme"
+assert_bump "none" "test: add tests"
+assert_bump "none" "chore: cleanup"
+assert_bump "none" "refactor: restructure"
+assert_bump "none" "chore(deps): update deps"
+
+echo ""
+echo "=== Priority Resolution ==="
+assert_bump "major" "$(printf 'feat: something\nfix!: breaking')"
+assert_bump "major" "$(printf 'docs: readme\nfeat!: breaking feature')"
+assert_bump "minor" "$(printf 'fix: bug\nfeat: feature')"
+assert_bump "minor" "$(printf 'docs: readme\nfeat: feature\nchore: cleanup')"
+assert_bump "patch" "$(printf 'docs: readme\nfix: bug')"
+assert_bump "patch" "$(printf 'chore: cleanup\nperf: speed up')"
+assert_bump "none" "$(printf 'docs: readme\nchore: cleanup\ntest: add test\nrefactor: clean')"
+
+echo ""
+echo "=== Version Arithmetic ==="
+assert_version_bump "1.0.0" "patch" "1.0.1"
+assert_version_bump "1.0.0" "minor" "1.1.0"
+assert_version_bump "1.0.0" "major" "2.0.0"
+assert_version_bump "1.2.3" "patch" "1.2.4"
+assert_version_bump "1.2.3" "minor" "1.3.0"
+assert_version_bump "1.2.3" "major" "2.0.0"
+assert_version_bump "0.9.9" "patch" "0.9.10"
+assert_version_bump "0.9.9" "minor" "0.10.0"
+assert_version_bump "0.9.9" "major" "1.0.0"
+assert_version_bump "10.20.30" "patch" "10.20.31"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Adds `auto-version.yml` workflow that bumps VERSION and creates a git tag on PR merge
- Conventional commits determine bump type: `feat:`→minor, `fix:/perf:`→patch, `!:/BREAKING CHANGE`→major
- `docs:`, `test:`, `chore:`, `refactor:` do not trigger a bump
- Adds 30 unit tests for the bump logic, integrated into CI

## Test plan
- [x] 30/30 tests passing locally (`tests/test-auto-version.sh`)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)