### PR TITLE
docs: sync workflow documentation with v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/github/license/vinicius91carvalho/.claude)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-workflow_system-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Languages](https://img.shields.io/badge/languages-16_supported-blue)](#supported-languages)
-[![Hooks](https://img.shields.io/badge/hooks-19_enforced-green)](#safety-enforcement-hooks)
+[![Hooks](https://img.shields.io/badge/hooks-18_enforced-green)](#safety-enforcement-hooks)
 
 A portable AI engineering system for Claude Code that applies automatically to every project. Built on the Compound Engineering philosophy: each unit of work makes subsequent units easier — not harder.
 
@@ -93,11 +93,13 @@ After shipping, `/compound` auto-captures learnings and promotes patterns — ma
 | `/create-project` | Greenfield project PRD with discovery interview and architecture defaults | "New project", "start a project", "build me an app" |
 | `/plan` | Generates PRD only | "Just plan, don't build yet" |
 | `/plan-build-test` | Plans, executes with agent teams, verifies locally | "Build this feature / fix this bug" |
+| `/research` | Deep multi-agent research via Stochastic Consensus & Debate | "How should I...", "compare approaches for...", "what's the best way to..." |
 | `/ship-test-ensure` | Branch, PR, staging E2E, production deploy, Lighthouse (optional) | "Ship what I've built" |
 | `/compound` | Captures learnings, updates error registry, evolves system | Auto-invoked after task completion |
 | `/workflow-audit` | Reviews model performance, error patterns, rule staleness | Monthly or after 10+ sessions |
 | `/update-docs` | Analyzes codebase and updates README/docs to match current code | "Update docs", "sync readme", or when push is blocked by stale docs |
-
+| `/find-skills` | Discovers and installs skills from the open agent skills ecosystem | "Find a skill for X", "is there a skill that can..." |
+| `/playwright-stealth` | Anti-detection browsing via Patchright + Xvfb for own content verification | "Stealth browse", "get page content", "check this site" |
 
 **Autonomous pipeline:** `/plan` → review PRD → `/plan-build-test` (autonomous) → manual test → `/ship-test-ensure` (autonomous through staging, confirms before production).
 
@@ -105,7 +107,7 @@ After shipping, `/compound` auto-captures learnings and promotes patterns — ma
 
 | Agent | Role | Model | Key Constraint |
 |---|---|---|---|
-| **Orchestrator** | Delegates, coordinates, merges | sonnet | Never implements code directly |
+| **Orchestrator** | Delegates, coordinates, merges | opus | Never implements code directly |
 | **Sprint Executor** | Implements sprints in isolation | sonnet | Cannot delegate to other agents |
 | **Code Reviewer** | Read-only post-merge audit | sonnet | Cannot modify any files |
 
@@ -115,21 +117,30 @@ The system uses deterministic hooks — real code that runs before/after every a
 
 | Hook | Trigger | What It Does |
 |---|---|---|
-| `block-dangerous.sh` | Every Bash command | Blocks `rm -rf /`, force push; project-aware package manager enforcement |
-| `check-test-exists.sh` | Every file edit | TDD gate — blocks production code edits without test file (16 languages) |
-| `check-invariants.sh` | Every file edit | Verifies INVARIANTS.md rules after edits |
-| `post-edit-quality.sh` | Every file edit | Auto-formats code using detected formatter (Biome, ruff, rustfmt, gofmt, etc.) |
-| `end-of-turn-typecheck.sh` | Session end | Static type checking (tsc, cargo check, go vet, mypy, pyright, etc.) |
-| `compound-reminder.sh` | Session end | Blocks exit without learning capture |
-| `verify-completion.sh` | Session end | Blocks premature completion without evidence |
+| `block-dangerous.sh` | PreToolUse(Bash) | Blocks `rm -rf /`, force push; project-aware package manager enforcement |
+| `block-heavy-bash.sh` | PreToolUse(Bash) | Soft-blocks heavy build/test commands in the main agent (delegate to subagent) |
+| `check-docs-updated.sh` | PreToolUse(Bash) | Blocks push if hooks/skills/agents changed without doc updates |
+| `check-test-exists.sh` | PreToolUse(Write/Edit) | TDD gate — blocks production code edits without test file (16 languages) |
+| `enforce-delegation.sh` | PreToolUse(Read/Grep/Bash/Agent) | Soft-blocks after 4+ direct reads; enforces orchestrator-delegates pattern |
+| `post-edit-quality.sh` | PostToolUse(Write/Edit) | Auto-formats code using detected formatter (Biome, ruff, rustfmt, gofmt, etc.) |
+| `check-invariants.sh` | PostToolUse(Write/Edit) | Verifies INVARIANTS.md rules after edits |
+| `scan-secrets.sh` | PostToolUse(Write/Edit) | Scans edited files for exposed secrets and credentials |
+| `end-of-turn-typecheck.sh` | Stop | Static type checking (tsc, cargo check, go vet, mypy, pyright, etc.) |
+| `cleanup-artifacts.sh` | Stop | Moves stray media files to `.artifacts/` and updates `.gitignore` |
+| `cleanup-worktrees.sh` | Stop | Prunes stale worktrees and removes merged sprint branches |
+| `compound-reminder.sh` | Stop | Blocks exit without learning capture |
+| `verify-completion.sh` | Stop | Blocks premature completion without evidence |
+| `session-start.sh` | SessionStart | Detects proot-distro ARM64, warns about issues, loads session state |
+| `reset-delegation-counter.sh` | UserPromptSubmit | Resets the delegation read counter each turn |
+| `compact-save.sh` | PreCompact | Saves session state before context compression |
+| `compact-restore.sh` | PostCompact | Restores session state after context compression |
 | `scripts/validate-i18n-keys.sh` | Pre-commit (via ship-test-ensure) | Cross-validates all i18n t() keys exist in all locale files |
 | `scripts/verify-worktree-merge.sh` | Post-merge (via orchestrator) | Detects files silently overwritten by worktree merges |
-| `check-docs-updated.sh` | Every `git push` (PreToolUse) | Blocks push if hooks/skills/agents changed without doc updates |
-| `session-start.sh` | SessionStart | Detects proot-distro ARM64, warns about issues, loads session state |
 | `scripts/worktree-preflight.sh` | Orchestrator step 0 | Detects project languages, installs deps per-language in worktrees |
 | `scripts/validate-sprint-boundaries.sh` | After sprint extraction | Validates no file conflicts between parallel sprints |
+| `scripts/harness-health.sh` | On-demand diagnostic | Validates hooks, settings, and system integrity |
 
-All hooks auto-detect the project's language(s) via `hooks/lib/detect-project.sh`. Adding support for a new language means updating one file — see [Universal Workflow Guide](docs/universal-workflow-guide.md).
+All hooks auto-detect the project's language(s) via `hooks/lib/detect-project.sh`. Adding support for a new language means updating one file — see [Universal Workflow Guide](docs/reference/universal-workflow-guide.md).
 
 #### Supported Languages
 
@@ -137,57 +148,100 @@ TypeScript, JavaScript, Python, Go, Rust, Ruby, Java, Kotlin, Elixir, Swift, Dar
 
 ### Workflow Integrity Tests
 
-The system includes a self-test suite (`test-workflow-mods/run-tests.sh`) with 123 assertions that validates the entire `~/.claude/` structure: hook existence and executability, settings.json registration and cross-references, CLAUDE.md documentation coverage, agent/skill structure, and evolution infrastructure. Runs automatically as the final step of `/compound` whenever workflow files are modified.
+The system includes a self-test suite (`test-workflow-mods/run-tests.sh`) with 405 assertions across 45 sections that validates the entire `~/.claude/` structure: hook existence and executability, settings.json registration and cross-references, CLAUDE.md documentation coverage, agent/skill structure, evolution infrastructure, and behavioral tests for key hooks. Runs automatically as the final step of `/compound` whenever workflow files are modified. Additional behavioral tests live in `hooks/tests/` (block-dangerous, block-heavy-bash, check-test-exists, enforce-delegation, scan-secrets).
 
 ## Repository Structure
 
 ```
 ~/.claude/
-├── CLAUDE.md          # The brain — all rules, workflows, and judgment protocols
-├── settings.json      # Deterministic enforcement via hooks
-├── agents/            # Specialized workers with isolated context windows
-│   ├── orchestrator.md    # Delegates and coordinates — never implements
-│   ├── sprint-executor.md # Implements sprints in isolated worktrees
-│   └── code-reviewer.md   # Read-only auditor — reports, never fixes
-├── skills/            # Auto-invocable step-by-step workflows
-│   ├── plan/              # PRD generation (/plan)
-│   ├── create-project/    # Greenfield project PRD with architecture defaults
-│   ├── plan-build-test/   # Local pipeline: discover → plan → execute → verify
-│   ├── ship-test-ensure/  # Deploy: branch → PR → staging → E2E → production
-│   ├── compound/          # Post-task learning capture
-│   ├── workflow-audit/    # Periodic system self-review
-│   └── update-docs/       # Analyze code and update project documentation
-├── hooks/             # Safety enforcement scripts (language-universal)
-│   ├── lib/
-│   │   └── detect-project.sh   # Shared language/project detection (16 languages)
-│   ├── block-dangerous.sh     # Blocks rm -rf, force push, project-aware pkg mgr
-│   ├── check-test-exists.sh   # TDD gate — blocks edits without test file (all langs)
-│   ├── check-invariants.sh    # Verifies INVARIANTS.md rules after edits
-│   ├── post-edit-quality.sh   # Auto-formats code after every edit (all langs)
-│   ├── end-of-turn-typecheck.sh # Static type checking (all langs)
-│   ├── compound-reminder.sh   # Blocks session end without learning capture
-│   ├── verify-completion.sh   # Blocks premature completion claims
-│   ├── check-docs-updated.sh # Blocks push if workflow changed without doc updates
-│   ├── scripts/               # Utility scripts called by skills/agents
-│   │   ├── approve.sh         # Soft-block approval mechanism
-│   │   ├── retry-with-backoff.sh # Retry helper for external API calls
-│   │   ├── validate-i18n-keys.sh # Cross-validates i18n keys across locales
+├── CLAUDE.md              # The brain — all rules, workflows, and judgment protocols
+├── settings.json          # Deterministic enforcement via hooks and permissions
+├── VERSION                # Semantic version of the workflow system
+├── set-compact.sh         # Context budget management (per-window autocompact)
+├── statusline-command.sh  # Status line display for the Claude Code UI
+├── agents/                # Specialized workers with isolated context windows
+│   ├── orchestrator.md        # Delegates and coordinates — never implements (opus)
+│   ├── sprint-executor.md     # Implements sprints in isolated worktrees (sonnet)
+│   └── code-reviewer.md       # Read-only auditor — reports, never fixes (sonnet)
+├── skills/                # Auto-invocable step-by-step workflows
+│   ├── plan/                  # PRD generation (/plan)
+│   ├── create-project/        # Greenfield project PRD with architecture defaults
+│   ├── plan-build-test/       # Local pipeline: discover → plan → execute → verify
+│   ├── research/              # Deep multi-agent research via Stochastic Consensus
+│   ├── ship-test-ensure/      # Deploy: branch → PR → staging → E2E → production
+│   ├── compound/              # Post-task learning capture
+│   ├── workflow-audit/        # Periodic system self-review
+│   ├── update-docs/           # Analyze code and update project documentation
+│   ├── playwright-stealth/    # Anti-detection browsing for content verification
+│   └── find-skills/           # Discover and install skills from the ecosystem
+├── rules/                 # Modular rule files included by CLAUDE.md via @rules/
+│   ├── workflow.md            # Sprint system, context engineering, agent architecture
+│   ├── quality.md             # Evaluation, self-improvement, session learnings
+│   └── environment.md         # PRoot-Distro ARM64 environment rules
+├── commands/              # Custom slash commands
+│   └── setup-hooks.md         # /setup-hooks — detect stack and verify hook config
+├── hooks/                 # Safety enforcement scripts (language-universal)
+│   ├── lib/                   # Shared libraries
+│   │   ├── detect-project.sh      # Language/project detection (16 languages)
+│   │   ├── approvals.sh           # Soft-block approval helpers
+│   │   ├── hook-logger.sh         # Hook execution logging
+│   │   ├── project-cache.sh       # Project detection caching
+│   │   └── stop-guard.sh          # Stop hook re-entrancy guard
+│   ├── block-dangerous.sh        # Blocks rm -rf, force push, project-aware pkg mgr
+│   ├── block-heavy-bash.sh       # Soft-blocks heavy build/test in main agent
+│   ├── check-test-exists.sh      # TDD gate — blocks edits without test file
+│   ├── check-invariants.sh       # Verifies INVARIANTS.md rules after edits
+│   ├── check-docs-updated.sh     # Blocks push if workflow changed without docs
+│   ├── post-edit-quality.sh      # Auto-formats code after every edit
+│   ├── scan-secrets.sh           # Scans for exposed secrets in edited files
+│   ├── enforce-delegation.sh     # Enforces orchestrator delegation pattern
+│   ├── reset-delegation-counter.sh # Resets read counter each turn
+│   ├── end-of-turn-typecheck.sh  # Static type checking (all langs)
+│   ├── cleanup-artifacts.sh      # Moves stray media to .artifacts/
+│   ├── cleanup-worktrees.sh      # Prunes stale worktrees
+│   ├── compact-save.sh           # Saves state before context compression
+│   ├── compact-restore.sh        # Restores state after context compression
+│   ├── compound-reminder.sh      # Blocks session end without learning capture
+│   ├── verify-completion.sh      # Blocks premature completion claims
+│   ├── session-start.sh          # Environment detection and session init
+│   ├── approve.sh                # Soft-block approval entry point
+│   ├── scripts/                  # Utility scripts called by skills/agents
+│   │   ├── approve.sh                # Batch approval mechanism
+│   │   ├── harness-health.sh         # System health diagnostic
+│   │   ├── retry-with-backoff.sh     # Retry helper for external API calls
+│   │   ├── validate-i18n-keys.sh     # Cross-validates i18n keys across locales
 │   │   ├── validate-sprint-boundaries.sh # Validates sprint file boundaries
-│   │   ├── verify-worktree-merge.sh # Detects silent overwrites in worktree merges
-│   │   └── worktree-preflight.sh # Language-aware worktree dependency setup
-├── test-workflow-mods/# Workflow integrity test suite (266 assertions)
+│   │   ├── verify-worktree-merge.sh  # Detects silent overwrites in merges
+│   │   └── worktree-preflight.sh     # Language-aware worktree dependency setup
+│   └── tests/                    # Behavioral tests for hooks
+│       ├── run-all.sh                # Runs all hook tests
+│       ├── test-block-dangerous.sh
+│       ├── test-block-heavy-bash.sh
+│       ├── test-check-test-exists.sh
+│       ├── test-enforce-delegation.sh
+│       └── test-scan-secrets.sh
+├── test-workflow-mods/    # Workflow integrity test suite (405 assertions)
 │   ├── run-tests.sh           # Validates entire ~/.claude/ structure
 │   └── testdata/              # Fixture projects for hook behavioral tests
-├── docs/              # Reference material (loaded on demand, not every session)
-│   ├── universal-workflow-guide.md  # How to use/extend for any language
-│   ├── evaluation-reference.md
-│   ├── anti-patterns-full.md
-│   ├── verification-gates.md
-│   ├── project-claude-md-template.md
-│   └── vague-requirements-translator.md
-├── workflow/          # Full documentation (you are here)
-└── evolution/         # Cross-project learning data
-    └── session-postmortems/    # Post-session analysis and learnings
+├── docs/                  # Reference material (loaded on demand, not every session)
+│   ├── on-demand/             # Detailed guides loaded by skills when needed
+│   │   ├── anti-patterns-full.md
+│   │   ├── browser-verification.md
+│   │   ├── dev-server-protocol.md
+│   │   ├── evaluation-reference.md
+│   │   ├── proot-distro-environment.md
+│   │   ├── vague-requirements-translator.md
+│   │   └── verification-gates.md
+│   └── reference/             # Templates and guides
+│       ├── model-assignment.md
+│       ├── project-claude-md-template.md
+│       └── universal-workflow-guide.md
+├── workflow/              # Full documentation
+└── evolution/             # Cross-project learning data
+    ├── error-registry.json    # Error patterns across projects
+    ├── model-performance.json # Model success rate tracking
+    ├── workflow-changelog.md  # System evolution history
+    └── session-postmortems/   # Post-session analysis and learnings
 ```
 
 ## Full Documentation

--- a/workflow/02-getting-started.md
+++ b/workflow/02-getting-started.md
@@ -93,7 +93,7 @@ Brief description of what this project is.
 - API routes go in `app/api/`
 ```
 
-A full template is available at `~/.claude/docs/project-claude-md-template.md`.
+A full template is available at `~/.claude/docs/reference/project-claude-md-template.md`.
 
 ### Why Execution Config Matters
 
@@ -133,8 +133,9 @@ The key insight: `CLAUDE.md` is the only file that costs context every session. 
 | `ENABLE_LSP_TOOL` | `"1"` | Enables Language Server Protocol for code navigation |
 | `NODE_OPTIONS` | `"--max-old-space-size=2048"` | Increases Node.js memory limit |
 | `CHOKIDAR_USEPOLLING` | `"true"` | Enables polling-based file watching |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `"62"` | Context auto-compact threshold (managed by `set-compact.sh`) |
 | `effortLevel` | `"high"` | Claude invests more reasoning in responses |
-| `defaultMode` | `"bypassPermissions"` | Allows autonomous execution (compensated by hooks) |
+| `permissions.allow` | Explicit list | Allows autonomous execution for listed tools (compensated by hooks) |
 
 ### Customization
 

--- a/workflow/03-architecture.md
+++ b/workflow/03-architecture.md
@@ -7,12 +7,15 @@
 ├── CLAUDE.md                           # The brain — all rules and workflows
 ├── README.md                           # Documentation for humans
 ├── settings.json                       # Deterministic enforcement — hooks & permissions
+├── VERSION                             # Semantic version of the workflow system
+├── set-compact.sh                      # Context budget management (per-window autocompact)
+├── statusline-command.sh               # Status line display for Claude Code UI
 ├── .gitignore                          # What NOT to version control
 │
 ├── agents/                             # Specialized agents with their own context
-│   ├── orchestrator.md                 # Project manager — delegates, never implements
-│   ├── sprint-executor.md              # Worker — implements a sprint in isolation
-│   └── code-reviewer.md               # Auditor — read-only, cannot modify code
+│   ├── orchestrator.md                 # Project manager — delegates, never implements (opus)
+│   ├── sprint-executor.md              # Worker — implements a sprint in isolation (sonnet)
+│   └── code-reviewer.md               # Auditor — read-only, cannot modify code (sonnet)
 │
 ├── skills/                             # Auto-invocable workflows
 │   ├── plan/                           # Planning and PRD generation
@@ -21,7 +24,11 @@
 │   │   ├── prd-template-minimal.md     # Minimal PRD template (Standard mode)
 │   │   ├── prd-template-full.md        # Full PRD template (PRD+Sprint mode)
 │   │   └── sprint-spec-template.md     # Sprint specification template
+│   ├── create-project/                 # Greenfield project PRD with architecture defaults
+│   │   └── SKILL.md
 │   ├── plan-build-test/                # Full local pipeline
+│   │   └── SKILL.md
+│   ├── research/                       # Deep multi-agent research (Stochastic Consensus)
 │   │   └── SKILL.md
 │   ├── ship-test-ensure/               # Deploy pipeline
 │   │   └── SKILL.md
@@ -29,37 +36,79 @@
 │   │   └── SKILL.md
 │   ├── workflow-audit/                 # Periodic system self-review
 │   │   └── SKILL.md
-│   └── update-docs/                   # Analyze code and update project docs
+│   ├── update-docs/                    # Analyze code and update project docs
+│   │   └── SKILL.md
+│   ├── playwright-stealth/             # Anti-detection browsing for content verification
+│   │   └── SKILL.md
+│   └── find-skills/                    # Discover and install skills from the ecosystem
 │       └── SKILL.md
 │
+├── rules/                              # Modular rule files included via @rules/
+│   ├── workflow.md                     # Sprint system, context engineering, agents
+│   ├── quality.md                      # Evaluation, self-improvement, session learnings
+│   └── environment.md                  # PRoot-Distro ARM64 environment rules
+│
+├── commands/                           # Custom slash commands
+│   └── setup-hooks.md                  # /setup-hooks — detect stack, verify hook config
+│
 ├── hooks/                              # Deterministic enforcement scripts
+│   ├── lib/                            # Shared libraries
+│   │   ├── detect-project.sh           # Language/project detection (16 languages)
+│   │   ├── approvals.sh               # Soft-block approval helpers
+│   │   ├── hook-logger.sh             # Hook execution logging
+│   │   ├── project-cache.sh           # Project detection caching
+│   │   └── stop-guard.sh             # Stop hook re-entrancy guard
 │   ├── block-dangerous.sh              # Blocks destructive commands
+│   ├── block-heavy-bash.sh             # Soft-blocks heavy build/test in main agent
 │   ├── check-test-exists.sh            # TDD gate — blocks edits without test file
 │   ├── check-invariants.sh             # Verifies INVARIANTS.md rules after edits
-│   ├── post-edit-quality.sh            # Auto-formats code after edits
-│   ├── end-of-turn-typecheck.sh        # Type-checks TypeScript at end of turn
+│   ├── check-docs-updated.sh           # Blocks push if workflow changed without docs
+│   ├── post-edit-quality.sh            # Auto-formats code after edits (all langs)
+│   ├── scan-secrets.sh                 # Scans for exposed secrets in edited files
+│   ├── enforce-delegation.sh           # Enforces orchestrator delegation pattern
+│   ├── reset-delegation-counter.sh     # Resets read counter each turn
+│   ├── end-of-turn-typecheck.sh        # Static type checking (all langs)
+│   ├── cleanup-artifacts.sh            # Moves stray media to .artifacts/
+│   ├── cleanup-worktrees.sh            # Prunes stale worktrees
+│   ├── compact-save.sh                 # Saves state before context compression
+│   ├── compact-restore.sh              # Restores state after context compression
 │   ├── compound-reminder.sh            # Blocks session end without learning capture
 │   ├── verify-completion.sh            # Blocks premature completion claims
-│   ├── check-docs-updated.sh           # Blocks push if workflow changed without docs
+│   ├── session-start.sh                # Environment detection and session init
+│   ├── approve.sh                      # Soft-block approval entry point
 │   ├── scripts/                        # Utility scripts called by skills/agents
-│   │   ├── approve.sh                  # Soft-block approval mechanism
-│   │   ├── retry-with-backoff.sh       # Utility for API rate limit handling
+│   │   ├── approve.sh                  # Batch approval mechanism
+│   │   ├── harness-health.sh           # System health diagnostic
+│   │   ├── retry-with-backoff.sh       # Retry helper for external API calls
 │   │   ├── validate-i18n-keys.sh       # Cross-validates i18n keys across locales
 │   │   ├── validate-sprint-boundaries.sh # Sprint file boundary validation
-│   │   ├── verify-worktree-merge.sh    # Detects silent overwrites in worktree merges
-│   │   └── worktree-preflight.sh       # Git and dependency readiness
+│   │   ├── verify-worktree-merge.sh    # Detects silent overwrites in merges
+│   │   └── worktree-preflight.sh       # Language-aware worktree dependency setup
+│   └── tests/                          # Behavioral tests for hooks
+│       ├── run-all.sh
+│       ├── test-block-dangerous.sh
+│       ├── test-block-heavy-bash.sh
+│       ├── test-check-test-exists.sh
+│       ├── test-enforce-delegation.sh
+│       └── test-scan-secrets.sh
 │
 ├── test-workflow-mods/                 # Workflow integrity test suite
-│   ├── run-tests.sh                    # 123 assertions validating ~/.claude/ structure
+│   ├── run-tests.sh                    # 405 assertions validating ~/.claude/ structure
 │   └── testdata/                       # Fixture projects for hook behavioral tests
 │
 ├── docs/                               # Reference material (loaded on demand)
-│   ├── evaluation-reference.md         # Quality evaluation checklists
-│   ├── anti-patterns-full.md           # 10 anti-patterns with examples and fixes
-│   ├── vague-requirements-translator.md
-│   ├── verification-gates.md           # 6 blocking verification gates
-│   ├── proot-distro-environment.md     # proot-distro ARM64 guide
-│   └── project-claude-md-template.md   # Template for project-specific CLAUDE.md
+│   ├── on-demand/                      # Detailed guides loaded by skills when needed
+│   │   ├── anti-patterns-full.md       # 10 anti-patterns with examples and fixes
+│   │   ├── browser-verification.md     # End-of-task browser verification protocol
+│   │   ├── dev-server-protocol.md      # Dev server management protocol
+│   │   ├── evaluation-reference.md     # Quality evaluation checklists
+│   │   ├── proot-distro-environment.md # proot-distro ARM64 guide
+│   │   ├── vague-requirements-translator.md
+│   │   └── verification-gates.md       # 6 blocking verification gates
+│   └── reference/                      # Templates and guides
+│       ├── model-assignment.md         # Model assignment reference
+│       ├── project-claude-md-template.md # Template for project-specific CLAUDE.md
+│       └── universal-workflow-guide.md # How to use/extend for any language
 │
 ├── workflow/                           # This documentation
 │

--- a/workflow/07-agents.md
+++ b/workflow/07-agents.md
@@ -7,7 +7,7 @@ Agents are specialized workers that live in `~/.claude/agents/`. Each has its **
 ```
 ┌───────────────────────────────────────────────────────────────────┐
 │                        ORCHESTRATOR                               │
-│  Model: sonnet  |  Tools: ALL (including Agent)                  │
+│  Model: opus    |  Tools: ALL (including Agent)                  │
 │  Role: Delegates, coordinates, merges. NEVER implements.          │
 │  Context: System instructions + progress.json + agent summaries  │
 │                                                                   │
@@ -54,7 +54,7 @@ maxTurns: 200
 
 | Agent | Model | Tools | Why This Model | Why These Tools |
 |---|---|---|---|---|
-| orchestrator | sonnet | ALL + Agent | Follows deterministic checklist; opus reserved for merge conflicts >3 files | Needs to spawn/manage other agents |
+| orchestrator | opus | ALL + Agent | Handles complex coordination, merge conflicts, and sprint lifecycle management | Needs to spawn/manage other agents |
 | sprint-executor | sonnet | Read, Write, Edit, Bash, Glob, Grep | Good cost-benefit for implementation work | Needs to write code but NOT delegate |
 | code-reviewer | sonnet | Read, Grep, Glob | Read-only analysis | ONLY read — reviewer must report, not fix |
 
@@ -113,9 +113,9 @@ Step 10: Return structured report with metrics
 
 **One orchestrator invocation = one batch.** After completing its batch, it returns control. The caller spawns the next orchestrator for the next batch, ensuring fresh context.
 
-### Why Sonnet (Not Opus)
+### Why Opus
 
-The orchestrator follows a deterministic checklist, not open-ended reasoning. It reads progress.json, finds the next batch, spawns agents, collects results, merges. This doesn't require the most powerful model. Opus is reserved for merge conflict resolution (>3 files) where genuine reasoning is needed.
+The orchestrator handles complex coordination: sprint lifecycle management, merge conflict resolution, coherence verification, and plan completeness audits. While it follows a deterministic checklist, the decisions at each step (conflict resolution, coherence assessment, when to mark blocked vs retry) benefit from stronger reasoning. The CLAUDE.md model assignment matrix specifies opus for sprint orchestration.
 
 ## The Sprint Executor
 

--- a/workflow/08-skills-reference.md
+++ b/workflow/08-skills-reference.md
@@ -36,6 +36,9 @@ Skills are auto-invocable workflows that live in `~/.claude/skills/`. Each skill
 │                      patterns, rule staleness.                         │
 │                                                                        │
 │    STANDALONE SKILLS (not part of the main pipeline):                  │
+│    /research            Deep multi-agent research (Stochastic          │
+│                         Consensus & Debate)                            │
+│    /find-skills         Discover and install skills from ecosystem     │
 │    /playwright-stealth  Anti-detection browsing for own content        │
 │                                                                        │
 └─────────────────────────────────────────────────────────────────────────┘
@@ -270,7 +273,7 @@ Steps 6-8: Cross-project promotion
 Step 9:    Write completion marker
 
 Step 10:   Workflow Integrity Gate (if ~/.claude/ files modified)
-           Run test-workflow-mods/run-tests.sh (112 assertions)
+           Run test-workflow-mods/run-tests.sh (405 assertions)
            ├── All pass → proceed
            └── Failures → fix before finalizing
 
@@ -357,6 +360,47 @@ Step 5: Report
 **Key principles:** Concise over verbose. Accurate over complete. Delete wrong docs rather than adding more. Examples over descriptions.
 
 **Trigger:** "update docs", "sync readme", "docs are stale", or auto-invoked when `check-docs-updated.sh` blocks a push.
+
+---
+
+## /research — Deep Multi-Agent Research
+
+**Trigger:** "how should I...", "what's the best way to...", "compare approaches for...", or `/research` explicitly.
+
+Uses **Stochastic Consensus & Debate**: spawns N researcher agents (sonnet) in parallel, each exploring a question from a distinct angle, then synthesizes with a single opus agent that weighs evidence quality, detects consensus, and arbitrates disagreements.
+
+### How It Works
+
+```
+Input: Question + optional N (default 5, range 3-10)
+    │
+    ▼
+Spawn N researcher agents (sonnet, parallel)
+    ├── Researcher 1: angle A (e.g., performance)
+    ├── Researcher 2: angle B (e.g., maintainability)
+    ├── ...
+    └── Researcher N: angle N (e.g., security)
+    │
+    ▼
+Synthesizer agent (opus)
+    ├── Weigh evidence quality per researcher
+    ├── Detect genuine consensus vs averaged opinions
+    ├── Arbitrate disagreements with reasoning
+    └── Produce actionable recommendations
+    │
+    ▼
+Output: Structured research report with confidence levels
+```
+
+**Not for:** Simple factual questions, code generation, task execution, or single-file fixes.
+
+---
+
+## /find-skills — Skill Discovery
+
+**Trigger:** "find a skill for X", "is there a skill that can...", "how do I do X" (when X might be a common task with an existing skill).
+
+Helps discover and install skills from the open agent skills ecosystem via the Skills CLI (`npx skills`). Searches for specialized capabilities, workflows, and tools that extend the agent's abilities.
 
 ---
 

--- a/workflow/09-hooks-and-enforcement.md
+++ b/workflow/09-hooks-and-enforcement.md
@@ -32,10 +32,20 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 │                        HOOK LIFECYCLE                               │
 │                                                                     │
 │  ┌──────────────────┐                                               │
+│  │  SessionStart    │ ◄── Runs once when session begins             │
+│  │  (always)        │     session-start.sh: env detection, state    │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  UserPromptSubmit│ ◄── Runs when user sends a new message        │
+│  │  (always)        │     reset-delegation-counter.sh: resets reads │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
 │  │  PreToolUse      │ ◄── Runs BEFORE every Bash command            │
 │  │  (Bash)          │     block-dangerous.sh: hard/soft blocks      │
-│  │                  │     (proot checks merged into session-start.sh) │
 │  │                  │     check-docs-updated.sh: doc sync on push   │
+│  │                  │     block-heavy-bash.sh: delegate heavy cmds  │
 │  └──────────────────┘                                               │
 │                                                                     │
 │  ┌──────────────────┐                                               │
@@ -45,14 +55,34 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 │  └──────────────────┘                                               │
 │                                                                     │
 │  ┌──────────────────┐                                               │
+│  │  PreToolUse      │ ◄── Runs BEFORE Read/Grep/Glob/Bash/Agent     │
+│  │  (Read|Grep|     │     enforce-delegation.sh: soft-blocks after  │
+│  │   Glob|Bash|     │     4+ direct reads — enforces orchestrator   │
+│  │   Task|Agent)    │     delegation pattern                        │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
 │  │  PostToolUse     │ ◄── Runs AFTER every Write/Edit/MultiEdit     │
-│  │  (Write|Edit|    │     post-edit-quality.sh: auto-format TS/JS   │
+│  │  (Write|Edit|    │     post-edit-quality.sh: auto-format code    │
 │  │   MultiEdit)     │     check-invariants.sh: verify INVARIANTS.md │
+│  │                  │     scan-secrets.sh: detect exposed secrets    │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  PreCompact      │ ◄── Runs BEFORE context compression           │
+│  │  (always)        │     compact-save.sh: saves session state      │
+│  └──────────────────┘                                               │
+│                                                                     │
+│  ┌──────────────────┐                                               │
+│  │  PostCompact     │ ◄── Runs AFTER context compression            │
+│  │  (always)        │     compact-restore.sh: restores session state│
 │  └──────────────────┘                                               │
 │                                                                     │
 │  ┌──────────────────┐                                               │
 │  │  Stop            │ ◄── Runs when the agent tries to end session  │
-│  │  (always)        │     end-of-turn-typecheck.sh: check TS types  │
+│  │  (always)        │     end-of-turn-typecheck.sh: static checking │
+│  │                  │     cleanup-artifacts.sh: moves stray media   │
+│  │                  │     cleanup-worktrees.sh: prunes worktrees    │
 │  │                  │     compound-reminder.sh: BLOCK if compound   │
 │  │                  │     hasn't run after task completion           │
 │  │                  │     verify-completion.sh: BLOCK if task marked │
@@ -76,18 +106,27 @@ While `CLAUDE.md` provides guidelines the model "should" follow, `settings.json`
 
 | Hook | Type | Trigger | Purpose | Blocking? |
 |---|---|---|---|---|
-| `block-dangerous.sh` | PreToolUse(Bash) | Every shell command | Block destructive operations; project-aware pkg mgr | Hard/soft block |
 | `session-start.sh` | SessionStart | Session begin | Detect proot, warn about issues, load session state | No (informational) |
+| `reset-delegation-counter.sh` | UserPromptSubmit | User message | Reset the delegation read counter each turn | No |
+| `block-dangerous.sh` | PreToolUse(Bash) | Every shell command | Block destructive operations; project-aware pkg mgr | Hard/soft block |
+| `check-docs-updated.sh` | PreToolUse(Bash) | `git push` | Block push if workflow files changed without doc updates | Yes (exit 2 if stale) |
+| `block-heavy-bash.sh` | PreToolUse(Bash) | Heavy commands | Soft-blocks build/test/lint commands in main agent | Soft block |
 | `check-test-exists.sh` | PreToolUse(Write/Edit) | Every file edit | TDD gate — require test file (16 languages) | Yes (exit 2 if missing) |
+| `enforce-delegation.sh` | PreToolUse(Read/Grep/etc) | 4+ direct reads | Soft-blocks main agent; enforces delegation to subagents | Soft block |
 | `post-edit-quality.sh` | PostToolUse(Write/Edit) | Every file edit | Auto-format code (all languages) | Yes (exit 2 on lint errors) |
 | `check-invariants.sh` | PostToolUse(Write/Edit) | Every file edit | Verify INVARIANTS.md rules | Yes (exit 2 on violation) |
+| `scan-secrets.sh` | PostToolUse(Write/Edit) | Every file edit | Scan for exposed secrets and credentials | Yes (exit 2 if found) |
+| `compact-save.sh` | PreCompact | Before compression | Save session state to survive context compression | No |
+| `compact-restore.sh` | PostCompact | After compression | Restore session state after context compression | No |
 | `end-of-turn-typecheck.sh` | Stop | End of turn | Static type checking (all languages) | Yes (exit 2 on type errors) |
+| `cleanup-artifacts.sh` | Stop | End of turn | Move stray media files to `.artifacts/` | No |
+| `cleanup-worktrees.sh` | Stop | End of turn | Prune stale worktrees and merged branches | No |
 | `compound-reminder.sh` | Stop | End of turn | Ensure /compound ran | Yes (exit 2 if skipped) |
 | `verify-completion.sh` | Stop | End of turn | Block premature completion | Yes (exit 2 without evidence) |
 | `validate-i18n-keys.sh` | (ship-test-ensure) | Pre-commit | Cross-validate i18n keys across locales | No (informational) |
 | `verify-worktree-merge.sh` | (orchestrator) | Post-merge | Detect silent overwrites from worktree merges | No (informational) |
-| `check-docs-updated.sh` | PreToolUse(Bash) | `git push` | Block push if workflow files changed without doc updates | Yes (exit 2 if stale) |
 | `worktree-preflight.sh` | (orchestrator) | Sprint start | Git/env readiness | N/A (utility) |
+| `harness-health.sh` | (on-demand) | Diagnostic | Validate hooks, settings, system integrity | N/A (utility) |
 | `retry-with-backoff.sh` | (utility) | API calls | Exponential backoff | N/A (utility) |
 
 ## PreToolUse: block-dangerous.sh
@@ -219,14 +258,20 @@ Was /compound run?
     "ENABLE_LSP_TOOL": "1",
     "NODE_OPTIONS": "--max-old-space-size=2048",
     "CHOKIDAR_USEPOLLING": "true",
-    "WATCHPACK_POLLING": "true"
+    "WATCHPACK_POLLING": "true",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "62"
   },
   "permissions": {
-    "defaultMode": "bypassPermissions",
+    "allow": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "Skill", "..."],
     "deny": []
   },
   "effortLevel": "high",
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline-command.sh"
+  },
+  "enabledPlugins": { "...": true }
 }
 ```
 
@@ -235,8 +280,11 @@ Was /compound run?
 | `ENABLE_LSP_TOOL` | Enables Language Server Protocol (goToDefinition, findReferences, etc.) |
 | `NODE_OPTIONS` | Increases Node.js memory limit (essential for proot-distro ARM64; harmless for non-Node projects) |
 | `CHOKIDAR_USEPOLLING` / `WATCHPACK_POLLING` | Enables polling-based file watching (Node.js only; harmless for others) |
-| `bypassPermissions` | Allows autonomous execution — compensated by hook safety |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Controls when context auto-compacts (per-window targets managed by `set-compact.sh`) |
+| `permissions.allow` | Explicit allow list of tools for autonomous execution — compensated by hook safety |
 | `effortLevel: "high"` | Claude invests more tokens/reasoning in responses |
+| `statusLine` | Custom status line command for the Claude Code UI |
+| `enabledPlugins` | Plugin system with marketplace plugins (frontend-design, context7, playwright, etc.) |
 
 ## Adding Custom Hooks
 
@@ -463,28 +511,38 @@ Find overlap (files touched by both)
 
 ## Workflow Integrity Tests
 
-The system includes a self-test suite at `~/.claude/test-workflow-mods/` that validates the entire `~/.claude/` structure.
+The system includes a self-test suite at `~/.claude/test-workflow-mods/` that validates the entire `~/.claude/` structure, plus behavioral tests for individual hooks in `~/.claude/hooks/tests/`.
 
-**What it tests (123 assertions across 16 sections):**
+**What it tests (405 assertions across 45 sections):**
 
 | Section | What It Validates |
 |---|---|
-| Hook scripts | All 9 executable hooks + 1 sourced utility exist with +x |
-| TDD enforcement | 8 behavioral tests (allow/block based on test file presence) |
-| Invariant verification | 5 behavioral tests (allow/block based on INVARIANTS.md rules) |
-| Anti-premature completion | 5 behavioral tests (evidence marker handling) |
-| Auto-format (Biome/ESLint) | 8 behavioral tests (skip non-TS, skip excluded dirs, detect configs) |
-| TypeScript type checking | 3 behavioral tests (skip conditions, tsconfig detection) |
+| Hook scripts | All executable hooks exist with +x permissions |
+| TDD enforcement | Behavioral tests (allow/block based on test file presence) |
+| Invariant verification | Behavioral tests (allow/block based on INVARIANTS.md rules) |
+| Anti-premature completion | Behavioral tests (evidence marker handling) |
+| Auto-format (Biome/ESLint) | Behavioral tests (skip non-code, skip excluded dirs, detect configs) |
+| TypeScript type checking | Behavioral tests (skip conditions, tsconfig detection) |
 | settings.json registration | Every hook registered to correct lifecycle event |
 | settings.json cross-reference | Every registered hook command points to existing file |
-| CLAUDE.md documentation | 18 key concepts documented |
+| settings.json structural | Validates JSON structure, env vars, permissions |
+| CLAUDE.md documentation | Key concepts documented across CLAUDE.md and @rules/ includes |
 | Agent definitions | 3 agents with correct frontmatter, model, and behavioral checks |
-| Skill definitions | 5 skills with SKILL.md and frontmatter |
+| Skill definitions | All skills with SKILL.md and frontmatter |
 | Plan skill | Build Candidate, INVARIANTS.md, support files |
 | PRD template | Structure and section numbering |
 | Sprint spec template | Consumed Invariants section |
 | Evolution infrastructure | JSON validity, backups, directory structure |
 | Compound self-test | Compound skill references test suite |
+| check-docs-updated.sh | Docs gate on git push behavioral tests |
+| create-project | Structure, discovery interview, architecture defaults, quality gate |
+| block-dangerous.sh | Hard blocks vs soft blocks, force push via +refspec |
+| Model assignment | Matrix compliance, agent frontmatter, skills consistency |
+| Delegation rules | Mandatory rules in CLAUDE.md |
+| Autocompact config | Per-window targets, SessionStart enforcement |
+| Context engineering | Rules documentation completeness |
+
+**Hook-level tests** (`hooks/tests/`): Additional behavioral tests for `block-dangerous.sh`, `block-heavy-bash.sh`, `check-test-exists.sh`, `enforce-delegation.sh`, and `scan-secrets.sh`.
 
 **When it runs:** Automatically as Step 10 of `/compound` when any `~/.claude/` file was modified. This ensures workflow modifications don't silently break the system.
 

--- a/workflow/10-evolution-and-learning.md
+++ b/workflow/10-evolution-and-learning.md
@@ -103,10 +103,12 @@ Tracks success rates per model per task type, enabling data-driven model selecti
 |---|---|
 | File scanning, discovery | haiku |
 | Simple fixes (lint, typos, CSS) | haiku |
+| Session learnings compilation | haiku |
 | Standard implementation | sonnet |
 | Bug fix implementation | sonnet |
 | Test writing | sonnet |
-| Sprint orchestration | sonnet |
+| Verification & regression scan | sonnet |
+| Sprint orchestration | opus |
 | Complex multi-file refactoring | opus |
 | Architectural decisions | opus |
 | Merge conflicts (>3 files) | opus |

--- a/workflow/15-glossary.md
+++ b/workflow/15-glossary.md
@@ -10,9 +10,11 @@
 | **Compound** | The phase where learnings from a task are captured and the system improves itself |
 | **Compound Engineering** | Engineering approach where each task not only delivers the result but improves the system for future tasks |
 | **Contract-First** | Pattern: user describes intent → agent mirrors understanding → user confirms before execution begins |
+| **Context Budget** | Per-window token targets for autocompact (128K: 100K, 200K: 125K, 1M: 150K) managed by `set-compact.sh` |
 | **Context Rot** | Quality degradation when the context window fills up, causing the model to "forget" earlier instructions |
 | **Context Window** | Maximum tokens the model can process at once — the model's "working memory" |
 | **Correctness Discovery** | 6-question framework for defining what "correct" means before building anything |
+| **Delegation** | Pattern where the main agent (orchestrator) delegates file reads and heavy commands to subagents, enforced by `enforce-delegation.sh` |
 | **E2E** | End-to-End testing — tests that simulate complete user flows through the application |
 | **Error Registry** | Cross-project database (`error-registry.json`) of error patterns, root causes, fixes, and failed approaches |
 | **Evolution** | The system's self-improvement mechanism — tracking errors, model performance, and system changes across all projects |
@@ -34,7 +36,9 @@
 | **Quick Fix** | Execution mode for trivial fixes — single file, < 30 lines, no architectural impact |
 | **Session Learnings** | File-based session memory that survives context compression (`/compact`) |
 | **Skill** | Auto-invocable workflow defined in `skills/` with a `SKILL.md` file |
-| **Sonnet** | Claude's balanced model — used for standard implementation, testing, bug fixes, and orchestration |
+| **Soft Block** | Hook-enforced pause that requires user approval to proceed (vs hard block which always denies) |
+| **Sonnet** | Claude's balanced model — used for standard implementation, testing, bug fixes, and code review |
+| **Stochastic Consensus** | Research method: N agents explore independently, then a synthesizer arbitrates — surfaces real disagreements instead of averaging |
 | **Sprint** | Self-contained unit of work within a PRD, designed for one agent in a healthy context window |
 | **Sprint Executor** | Agent that receives a sprint spec and implements it within an isolated worktree |
 | **TDD** | Test-Driven Development — write tests before production code (Red → Green → Refactor) |

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -16,7 +16,7 @@ Detailed documentation for the Claude Workflow System. See the [main README](../
 
 ### Components
 7. [Agents](07-agents.md) — Orchestrator, Sprint Executor, Code Reviewer
-8. [Skills Reference](08-skills-reference.md) — /plan, /plan-build-test, /ship-test-ensure, /compound, /workflow-audit
+8. [Skills Reference](08-skills-reference.md) — /plan, /plan-build-test, /research, /ship-test-ensure, /compound, /workflow-audit, /update-docs, /find-skills, /playwright-stealth
 9. [Hooks & Enforcement](09-hooks-and-enforcement.md) — settings.json, hook lifecycle, adding custom hooks
 10. [Evolution & Learning](10-evolution-and-learning.md) — Cross-project learning, error registry, model performance
 


### PR DESCRIPTION
## Summary
- Fix orchestrator model reference (sonnet → opus) across README, agents, and workflow docs
- Add 3 missing skills to documentation: `/research`, `/find-skills`, `/playwright-stealth`
- Expand hooks table from 13 to 22 entries, add 5 missing lifecycle events
- Rewrite repository structure trees to match actual file layout
- Fix test assertion counts and stale file paths
- Add 4 glossary terms: Context Budget, Delegation, Soft Block, Stochastic Consensus

## Files changed (10)
- `README.md` — Main readme rewrite (skills, hooks, structure, badges)
- `workflow/README.md` — Skills reference count
- `workflow/02-getting-started.md` — Fixed paths and settings table
- `workflow/03-architecture.md` — Complete structure tree rewrite
- `workflow/07-agents.md` — Orchestrator model fix
- `workflow/08-skills-reference.md` — Added /research and /find-skills
- `workflow/09-hooks-and-enforcement.md` — Hook lifecycle, table, tests
- `workflow/10-evolution-and-learning.md` — Model assignment table fix
- `workflow/15-glossary.md` — 4 new terms

## Test plan
- [x] Pre-commit hook ran 405 test assertions — all passed
- [x] All referenced file paths verified to exist
- [x] 0 broken links detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)