### PR TITLE
docs: enforce session hygiene across plan, plan-build-test, and ship-test-ensure

### DIFF
--- a/skills/plan-build-test/SKILL.md
+++ b/skills/plan-build-test/SKILL.md
@@ -206,37 +206,52 @@ Execute task batches in order. The execution strategy depends on whether a task 
 - **PRD+Sprint task** — Has a `progress.json` with sprint entries → delegate to **orchestrator agent** (one per batch)
 - **Simple task** — Standard checklist without sprint structure → execute with **general-purpose agent**
 
-### Step 3.1: For PRD+Sprint Tasks — One Orchestrator Per Batch
+### Step 3.1: For PRD+Sprint Tasks — One Batch Per Session (HARD RULE)
 
-**CRITICAL: Spawn one orchestrator agent per batch. Each gets fresh context.**
+**CRITICAL: This skill executes EXACTLY ONE batch per session, then stops.**
+The main agent does NOT loop through batches. Multi-batch loops in the main
+agent accumulate context (orchestrator return reports + progress.json re-reads
++ session-learnings updates) and trigger repeated `/compact`, turning a short
+PRD into hours of degraded execution. The user starts a fresh
+`/plan-build-test` session per batch — Phase 0 picks up the next pending batch
+from `progress.json`.
 
-Read `progress.json` to determine batch order. Loop:
+Execute exactly ONE batch:
 
-```
-for each batch (ordered by batch number):
-  1. Read progress.json for current state
-  2. Read session learnings for accumulated rules
-  3. Read previous batch's Agent Notes from sprint spec files
-  4. Spawn orchestrator agent for THIS batch only:
+1. Read `progress.json` — find the lowest-numbered batch whose sprints are
+   `not_started` or `in_progress`. This is THE batch for this session.
+2. Read session learnings for accumulated rules.
+3. Read previous batch's Agent Notes from prior sprint spec files (if any).
+4. Spawn orchestrator agent for THIS batch only:
 
-     Agent(description: "Batch N: Sprint(s) [X,Y]",
-           prompt: "Execute batch N.
+   Agent(description: "Batch N: Sprint(s) [X,Y]",
+         prompt: "Execute batch N.
 
-           PRD directory: [path]
-           progress.json path: [path]
-           Batch assignment: Sprints [list]
-           Previous Agent Notes: [from prior sprint spec files]
-           Execution Config: [commands from project CLAUDE.md]
-           Session learnings rules: [relevant rules]
-           Context files: [key reference files]",
-           subagent_type: "orchestrator",
-           model: "opus")
+         PRD directory: [path]
+         progress.json path: [path]
+         Batch assignment: Sprints [list]
+         Previous Agent Notes: [from prior sprint spec files]
+         Execution Config: [commands from project CLAUDE.md]
+         Session learnings rules: [relevant rules]
+         Context files: [key reference files]",
+         subagent_type: "orchestrator",
+         model: "opus")
 
-  5. Receive results from orchestrator
-  6. Re-read progress.json (orchestrator updated it)
-  7. Update session learnings (status, errors, new rules)
-  8. If batch had blocked sprints: decide whether to continue or stop
-```
+5. Receive results from orchestrator.
+6. Re-read progress.json (orchestrator updated it).
+7. Update session learnings (status, errors, new rules from this batch only).
+8. Route based on progress.json state:
+   - **More `not_started`/`in_progress` batches remain:**
+     Report batch N results. Tell user: "Batch N done. **Start a new session
+     and run `/plan-build-test` again** to pick up batch N+1 from
+     progress.json." **STOP. Do NOT proceed to Phase 4/5/6.** The next
+     session's Phase 0 resume gate will pick up where this one left off.
+   - **ALL batches complete:**
+     Proceed to Phase 4 (Post-Implementation Review), then Phase 5 (Live
+     Verification), then Phase 6 (Learning). These phases only run on the
+     session that finishes the final batch.
+   - **Batch had blocked sprints:** Report blocked state and STOP — user
+     decides retry / re-plan / abandon.
 
 ### Step 3.2: For Simple Tasks — General-Purpose Agent
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -49,6 +49,6 @@ description: >
    contracts for cross-cutting concepts) → run `bash ~/.claude/hooks/scripts/validate-sprint-boundaries.sh <prd-dir>`
    → tag Build Candidate (`git tag "build-candidate/<prd-name>"`). Maximum 5 sprints per PRD.
 
-5. Tell the user: "PRD saved at [directory-path]/. Sprint specs extracted to `sprints/`. INVARIANTS.md created. Build Candidate tagged. Run `/plan-build-test` to execute, or review and adjust first."
+5. Tell the user: "PRD saved at [directory-path]/. Sprint specs extracted to `sprints/`. INVARIANTS.md created. Build Candidate tagged. **Stop this session.** Open a fresh session and run `/plan-build-test` to execute — do NOT continue in this window. Keeping planning and execution in separate context windows prevents `/compact` churn during the build."
 
-6. **Do NOT execute.** This skill produces the plan only.
+6. **Do NOT execute. Do NOT invoke `/plan-build-test` from this session**, even if the user's next message asks for it — tell them to start a new session instead (context hygiene). This skill produces the plan only.

--- a/skills/ship-test-ensure/SKILL.md
+++ b/skills/ship-test-ensure/SKILL.md
@@ -76,15 +76,30 @@ If this IS a fresh context (first message or resumed from session learnings), sk
 
 ### Step 0.2: Determine Which App(s) to Ship
 
-Detect which app(s) have changes:
+**Sprint state is optional.** This skill does not require a `progress.json` or
+completed sprint record — it ships whatever diverges from the remote. If PRD
+state happens to exist, it's informational only; the authoritative signal is
+"what is not yet on the tracking remote".
+
+Detect all unpushed changes:
 
 ```bash
-git diff --name-only HEAD~1 HEAD
-git diff --name-only  # unstaged changes
-git diff --name-only --cached  # staged changes
+# All commits on the current branch not yet on the tracking remote branch
+git log @{upstream}..HEAD --oneline 2>/dev/null || git log origin/main..HEAD --oneline
+# Files changed across those commits
+git diff @{upstream}..HEAD --name-only 2>/dev/null || git diff origin/main..HEAD --name-only
+# Plus working tree
+git diff --name-only              # unstaged
+git diff --name-only --cached     # staged
 ```
 
-Categorize changed files using `app_detection_paths` from Execution Config. Determine: which app(s) are affected, or if only shared packages changed (which affects all apps).
+Union the three file lists. Categorize using `app_detection_paths` from
+Execution Config. Determine which app(s) are affected (or if only shared
+packages changed — affects all apps).
+
+**If there are zero unpushed commits AND zero staged/unstaged changes:** report
+"nothing to ship — working tree matches remote" and stop. Do not fabricate a
+no-op commit.
 
 ### Step 0.3: Local Verification Gate
 


### PR DESCRIPTION
## Summary
- `/plan` — force a fresh session before `/plan-build-test`; refuse to execute in the same window.
- `/plan-build-test` — exactly **one batch per session** (prevents `/compact` churn across batches).
- `/ship-test-ensure` — sprint state is optional; authoritatively detect unpushed commits + working-tree changes, and abort cleanly if nothing diverges from remote.

## Test plan
- [ ] Run `/plan` on a sample PRD — confirm final step instructs fresh-session handoff.
- [ ] Run `/plan-build-test` on a multi-batch PRD — confirm it stops after batch 1 with a resume message.
- [ ] Run `/ship-test-ensure` on a clean tree — confirm it aborts with "nothing to ship".

Generated by /ship-test-ensure pipeline (Phase 1 only — repo has no CI/CD deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)